### PR TITLE
Dramatically simplifying surface area of persist package.

### DIFF
--- a/persist/load.go
+++ b/persist/load.go
@@ -23,10 +23,7 @@ import (
 
 // Loader can instantiate core envelopes objects given just an ID.
 type Loader interface {
-	LoadAccounts(context.Context, envelopes.ID) (envelopes.Accounts, error)
-	LoadBudget(context.Context, envelopes.ID) (envelopes.Budget, error)
-	LoadState(context.Context, envelopes.ID) (envelopes.State, error)
-	LoadTransaction(context.Context, envelopes.ID) (envelopes.Transaction, error)
+	Load(ctx context.Context, id envelopes.ID, destination envelopes.IDer) error
 }
 
 // DefaultLoader wraps a Fetcher and does just the unmarshaling portion.
@@ -34,64 +31,11 @@ type DefaultLoader struct {
 	Fetcher
 }
 
-func (dl DefaultLoader) load(ctx context.Context, id envelopes.ID, target interface{}) (err error) {
+func (dl DefaultLoader) Load(ctx context.Context, id envelopes.ID, destination envelopes.IDer) (err error) {
 	contents, err := dl.Fetch(ctx, id)
 	if err != nil {
 		return
 	}
 
-	err = json.Unmarshal(contents, target)
-	return
-}
-
-func LoadAll(ctx context.Context, loader Loader, id envelopes.ID) (envelopes.Transaction, envelopes.State, envelopes.Accounts, envelopes.Budget, error) {
-	loadedTransaction, err := loader.LoadTransaction(ctx, id)
-	if err != nil {
-		return envelopes.Transaction{}, envelopes.State{}, envelopes.Accounts{}, envelopes.Budget{}, err
-	}
-
-	loadedState, err := loader.LoadState(ctx, loadedTransaction.State())
-	if err != nil {
-		return envelopes.Transaction{}, envelopes.State{}, envelopes.Accounts{}, envelopes.Budget{}, err
-	}
-
-	loadedAccounts, err := loader.LoadAccounts(ctx, loadedState.Accounts())
-	if err != nil {
-		return envelopes.Transaction{}, envelopes.State{}, envelopes.Accounts{}, envelopes.Budget{}, err
-	}
-
-	loadedBudget, err := loader.LoadBudget(ctx, loadedState.Budget())
-	if err != nil {
-		return envelopes.Transaction{}, envelopes.State{}, envelopes.Accounts{}, envelopes.Budget{}, err
-	}
-
-	return loadedTransaction, loadedState, loadedAccounts, loadedBudget, nil
-}
-
-func (dl DefaultLoader) LoadAll(ctx context.Context, id envelopes.ID) (envelopes.Transaction, envelopes.State, envelopes.Accounts, envelopes.Budget, error) {
-	return LoadAll(ctx, dl, id)
-}
-
-// LoadAccounts fetches a list of Accounts in its marshaled form, then unmarshals it into an Accounts object.
-func (dl DefaultLoader) LoadAccounts(ctx context.Context, id envelopes.ID) (loaded envelopes.Accounts, err error) {
-	err = dl.load(ctx, id, &loaded)
-	return
-}
-
-// LoadBudget fetches a Budget in its marshaled form, then unmarshals it into a Budget object.
-func (dl DefaultLoader) LoadBudget(ctx context.Context, id envelopes.ID) (loaded envelopes.Budget, err error) {
-	err = dl.load(ctx, id, &loaded)
-	return
-}
-
-// LoadState fetches a State in its marshaled form, then unmarshals it into a State object.
-func (dl DefaultLoader) LoadState(ctx context.Context, id envelopes.ID) (loaded envelopes.State, err error) {
-	err = dl.load(ctx, id, &loaded)
-	return
-}
-
-// LoadTransaction fetches a Transaction in its marshaled form, then unmarshals it into a Transaction object.
-func (dl DefaultLoader) LoadTransaction(ctx context.Context, id envelopes.ID) (loaded envelopes.Transaction, err error) {
-	err = dl.load(ctx, id, &loaded)
-	return
+	return json.Unmarshal(contents, destination)
 }

--- a/persist/write.go
+++ b/persist/write.go
@@ -15,62 +15,13 @@
 package persist
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
-
 	"github.com/marstr/envelopes"
 )
 
 // Writer defines a contract that allows an object to express that it knows how to persist
 // an object so that it can be recalled using an instance of an object that satisfies `persist.Fetch`.
 type Writer interface {
-	WriteAccounts(context.Context, envelopes.Accounts) error
-	// WriteBudget must persist a budget in a means that it is fetchable using a `persist.Fetch`.
-	WriteBudget(context.Context, envelopes.Budget) error
-	// WriteCurrent stores the ID of the Transaction that should be considered the most up-to-date one.
-	WriteCurrent(context.Context, envelopes.Transaction) error
-	// WriteState must persist a budget in a means that it is fetchable using a `persist.Fetch`.
-	WriteState(context.Context, envelopes.State) error
-	// WriteTransaction must persist a budget in a means that it is fetchable using a `persist.Fetch`.
-	WriteTransaction(context.Context, envelopes.Transaction) error
-}
-
-func WriteAll(ctx context.Context, writer Writer, t envelopes.Transaction, s envelopes.State, a envelopes.Accounts, b envelopes.Budget) (err error) {
-	encounteredErrs := new(bytes.Buffer)
-	if got := a.ID(); !s.Accounts().Equal(got) {
-		fmt.Fprintf(encounteredErrs, "expected Account to have ID %q\n", got)
-	}
-
-	if got := b.ID(); !s.Budget().Equal(got) {
-		fmt.Fprintf(encounteredErrs, "expected Budget to have ID %q\n", got)
-	}
-
-	if got := s.ID(); !t.State().Equal(got) {
-		fmt.Fprintf(encounteredErrs, "expected State to have ID %q\n", got)
-	}
-
-	if encounteredErrs.Len() > 0 {
-		err = errors.New(encounteredErrs.String())
-		return
-	}
-
-	err = writer.WriteAccounts(ctx, a)
-	if err != nil {
-		return
-	}
-
-	err = writer.WriteBudget(ctx, b)
-	if err != nil {
-		return
-	}
-
-	err = writer.WriteState(ctx, s)
-	if err != nil {
-		return
-	}
-
-	err = writer.WriteTransaction(ctx, t)
-	return
+	// Write persists an object in durable storage where it can be retreived later.
+	Write(ctx context.Context, subject envelopes.IDer) error
 }


### PR DESCRIPTION
While working with this library in [marstr/baronial](https://github.com/marstr/baronial), I felt like I was doing a lot more typing than was necessary without value. This ought to help.