### PR TITLE
Adding github.com/devigned/tab instrumentation to all functions taking a context.Context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/marstr/envelopes
 
 require github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747
 
-require github.com/marstr/collection v1.0.1
+require (
+	github.com/devigned/tab v0.1.1
+	github.com/marstr/collection v1.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/devigned/tab v0.1.1 h1:3mD6Kb1mUOYeLpJvTVSDwSg5ZsfSxfvxGRTxRsJsITA=
+github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/marstr/collection v1.0.1 h1:j61osRfyny7zxBlLRtoCvOZ2VX7HEyybkZcsLNLJ0z0=
 github.com/marstr/collection v1.0.1/go.mod h1:HHDXVxjLO3UYCBXJWY+J/ZrxCUOYqrO66ob1AzIsmYA=
 github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747 h1:eQox4Rh4ewJF+mqYPxCkmBAirRnPaHEB26UkNuPyjlk=

--- a/persist/write.go
+++ b/persist/write.go
@@ -20,8 +20,12 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/devigned/tab"
+
 	"github.com/marstr/envelopes"
 )
+
+const defaultWriteroperationPrefix = persistOperationPrefix + ".DefaultWriter"
 
 type (
 	// Writer defines a contract that allows an object to express that it knows how to persist
@@ -39,14 +43,23 @@ type (
 
 // Write uses the Stasher it is composed of to write the given Envelopes object to a persistent storage space.
 func (dw DefaultWriter) Write(ctx context.Context, subject envelopes.IDer) error {
+	var span tab.Spanner
+	const operationName = defaultWriteroperationPrefix + ".Write"
+	ctx, span = tab.StartSpan(ctx, operationName)
+	defer span.End()
+
 	// In recursive methods, it is easy to detect that a context has been cancelled between calls to itself.
 	// Must have default clause to prevent blocking.
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		err := ctx.Err()
+		span.Logger().Error(err)
+		return err
 	default:
 		// Intentionally Left Blank
 	}
+
+	span.AddAttributes(tab.StringAttribute("entityType", reflect.TypeOf(subject).Name()))
 
 	switch subject.(type) {
 	case envelopes.Transaction:
@@ -66,11 +79,18 @@ func (dw DefaultWriter) Write(ctx context.Context, subject envelopes.IDer) error
 	case *envelopes.Accounts:
 		return dw.writeAccounts(ctx, *subject.(*envelopes.Accounts))
 	default:
-		return fmt.Errorf("unknown type: %s", reflect.TypeOf(subject).Name())
+		err := fmt.Errorf("unknown type: %s", reflect.TypeOf(subject).Name())
+		span.Logger().Error(err)
+		return err
 	}
 }
 
 func (dw DefaultWriter) writeTransaction(ctx context.Context, subject envelopes.Transaction) error {
+	var span tab.Spanner
+	const operationName = defaultWriteroperationPrefix + ".writeTransaction"
+	ctx, span = tab.StartSpan(ctx, operationName)
+	defer span.End()
+
 	if subject.State == nil {
 		subject.State = &envelopes.State{}
 	}
@@ -85,11 +105,13 @@ func (dw DefaultWriter) writeTransaction(ctx context.Context, subject envelopes.
 
 	err := dw.Write(ctx, subject.State)
 	if err != nil {
+		span.Logger().Error(err)
 		return err
 	}
 
 	marshaled, err := json.Marshal(toMarshal)
 	if err != nil {
+		span.Logger().Error(err)
 		return err
 	}
 
@@ -97,11 +119,17 @@ func (dw DefaultWriter) writeTransaction(ctx context.Context, subject envelopes.
 }
 
 func (dw DefaultWriter) writeState(ctx context.Context, subject envelopes.State) error {
+	var span tab.Spanner
+	const operationName = defaultWriteroperationPrefix + ".writeState"
+	ctx, span = tab.StartSpan(ctx, operationName)
+	defer span.End()
+
 	if subject.Accounts == nil {
 		subject.Accounts = make(envelopes.Accounts, 0)
 	}
 	err := dw.Write(ctx, subject.Accounts)
 	if err != nil {
+		span.Logger().Error(err)
 		return err
 	}
 
@@ -110,6 +138,7 @@ func (dw DefaultWriter) writeState(ctx context.Context, subject envelopes.State)
 	}
 	err = dw.Write(ctx, subject.Budget)
 	if err != nil {
+		span.Logger().Error(err)
 		return err
 	}
 
@@ -119,6 +148,7 @@ func (dw DefaultWriter) writeState(ctx context.Context, subject envelopes.State)
 
 	marshaled, err := json.Marshal(toMarshal)
 	if err != nil {
+		span.Logger().Error(err)
 		return err
 	}
 
@@ -126,12 +156,18 @@ func (dw DefaultWriter) writeState(ctx context.Context, subject envelopes.State)
 }
 
 func (dw DefaultWriter) writeBudget(ctx context.Context, subject envelopes.Budget) error {
+	var span tab.Spanner
+	const operationName = defaultWriteroperationPrefix + ".writeBudget"
+	ctx, span = tab.StartSpan(ctx, operationName)
+	defer span.End()
+
 	if subject.Children == nil {
 		subject.Children = make(map[string]*envelopes.Budget, 0)
 	}
 	for _, child := range subject.Children {
 		err := dw.Write(ctx, child)
 		if err != nil {
+			span.Logger().Error(err)
 			return err
 		}
 	}
@@ -145,6 +181,7 @@ func (dw DefaultWriter) writeBudget(ctx context.Context, subject envelopes.Budge
 
 	marshaled, err := json.Marshal(toMarshal)
 	if err != nil {
+		span.Logger().Error(err)
 		return err
 	}
 
@@ -152,8 +189,14 @@ func (dw DefaultWriter) writeBudget(ctx context.Context, subject envelopes.Budge
 }
 
 func (dw DefaultWriter) writeAccounts(ctx context.Context, subject envelopes.Accounts) error {
+	var span tab.Spanner
+	const operationName = defaultWriteroperationPrefix + ".writeAccounts"
+	ctx, span = tab.StartSpan(ctx, operationName)
+	defer span.End()
+
 	marshaled, err := json.Marshal(subject)
 	if err != nil {
+		span.Logger().Error(err)
 		return err
 	}
 


### PR DESCRIPTION
This will allow for the export of tracing data to OpenTracing or OpenCensus, and go a long way to allowing for the building of observable applications on top of this library.