### PR TITLE
Add rudimentary cloning capability to FileSystem type

### DIFF
--- a/persist/filesystem.go
+++ b/persist/filesystem.go
@@ -270,7 +270,7 @@ func (fs FileSystem) ListBranches(ctx context.Context) (<-chan string, error) {
 		defer close(castResults)
 
 		for entry := range rawResults {
-			entry = strings.ReplaceAll(entry.(string), "\\", "/")
+			entry = strings.Replace(entry.(string), "\\", "/", -1)
 			trimmed := strings.TrimPrefix(entry.(string), prefix)
 			select {
 			case <-ctx.Done():

--- a/persist/filesystem.go
+++ b/persist/filesystem.go
@@ -264,7 +264,7 @@ func (fs FileSystem) ListBranches(ctx context.Context) (<-chan string, error) {
 	rawResults := dir.Enumerate(ctx.Done())
 
 	prefix := absRoot + "/"
-	prefix = strings.ReplaceAll(prefix, "\\", "/")
+	prefix = strings.Replace(prefix, "\\", "/", -1)
 	castResults := make(chan string)
 	go func() {
 		defer close(castResults)

--- a/persist/filesystem.go
+++ b/persist/filesystem.go
@@ -283,3 +283,54 @@ func (fs FileSystem) ListBranches(ctx context.Context) (<-chan string, error) {
 
 	return castResults, nil
 }
+
+// Clone uses an arbitrary Loader to retrieve all transactions that are ancestors of a specified Transaction. As it
+// acquires each Transaction, it writes it to disk.
+func (fs FileSystem) Clone(ctx context.Context, walkStart envelopes.ID, branchName string, loader Loader) error {
+	err := fs.copyTransactions(ctx, walkStart, loader)
+	if err != nil {
+		return err
+	}
+
+	err = fs.WriteBranch(ctx, branchName, walkStart)
+	if err != nil {
+		return err
+	}
+
+	localLoader := DefaultLoader{Fetcher: fs}
+	var head envelopes.Transaction
+	err = localLoader.Load(ctx, walkStart, &head)
+	if err != nil {
+		return err
+	}
+
+	return fs.SetCurrent(ctx, RefSpec(branchName))
+}
+
+func (fs FileSystem) copyTransactions(ctx context.Context, walkStart envelopes.ID, loader Loader) error {
+	next := walkStart
+
+	writer := DefaultWriter{
+		Stasher: fs,
+	}
+
+	var current envelopes.Transaction
+	for {
+		err := loader.Load(ctx, next, &current)
+		if err != nil {
+			return err
+		}
+
+		err = writer.Write(ctx, current)
+		if err != nil {
+			return err
+		}
+
+		if current.Parent.Equal(envelopes.ID{}) {
+			break
+		}
+		next = current.Parent
+	}
+
+	return nil
+}


### PR DESCRIPTION
This change seeks to add the ability to do basic copy operations of a repository.

Notable missing behavior:
- Reuse of file system objects by using hardlinks instead of actually copying the files.
- While this will work with any Loader handed to it, no new fetchers are implemented here.