### PR TITLE
Adding Repository interface collections

### DIFF
--- a/persist/branch.go
+++ b/persist/branch.go
@@ -26,10 +26,13 @@ const (
 	DefaultBranch = "master"
 )
 
-// Brancher defines the requirements for a type to be able to provide the functionality
-// required to manage branches.
-type Brancher interface {
+// BranchReader indicates that a type is capable of discovering the envelopes.Transaction that a branch points at.
+type BranchReader interface {
 	ReadBranch(ctx context.Context, name string) (envelopes.ID, error)
+}
+
+// BranchWriter indicates that a type is capable of update the envelopes.Transaction that a branch points at.
+type BranchWriter interface {
 	WriteBranch(ctx context.Context, name string, id envelopes.ID) error
 }
 

--- a/persist/branch.go
+++ b/persist/branch.go
@@ -36,6 +36,12 @@ type BranchWriter interface {
 	WriteBranch(ctx context.Context, name string, id envelopes.ID) error
 }
 
+// BranchReaderWriter indicates that a types has both the capabilities of a BranchReader and BranchWriter.
+type BranchReaderWriter interface {
+	BranchReader
+	BranchWriter
+}
+
 // BranchLister are able to find all branches is a repository.
 type BranchLister interface {
 	ListBranches(ctx context.Context) (<-chan string, error)

--- a/persist/current.go
+++ b/persist/current.go
@@ -2,8 +2,6 @@ package persist
 
 import (
 	"context"
-
-	"github.com/marstr/envelopes"
 )
 
 // CurrentReaderWriter exposes a contract that requires both CurrentReader and CurrentWriter functionality to be
@@ -15,7 +13,7 @@ type CurrentReaderWriter interface {
 
 // CurrentReader allows the caller to view the state of the CurrentPointer.
 type CurrentReader interface {
-	// CurrentRef finds an identifier for the most recent Transaction that has been committed. Most times, this is the
+	// Current finds an identifier for the most recent Transaction that has been committed. Most times, this is the
 	// name of the current branch. A repository could also be in HEADless mode, in which case this will return a
 	// Transaction ID instead.
 	Current(ctx context.Context) (RefSpec, error)
@@ -23,11 +21,6 @@ type CurrentReader interface {
 
 // CurrentWriter allows the caller to modify the state of the Current pointer.
 type CurrentWriter interface {
-	// WriteCurrent updates the most recently committed transaction. If the repository is in HEADless mode, this will
-	// just update the current Transaction ID. If the repository has a branch checked out, this will update the commit
-	// that the branch points to.
-	WriteCurrent(ctx context.Context, current envelopes.Transaction) error
-
 	// SetCurrent updates which Transaction is currently said to be checked out. It literally replaces the current
 	// pointer, and should be used when switching branches or moving between transactions in HEADless mode.
 	SetCurrent(ctx context.Context, current RefSpec) error

--- a/persist/filesystem_test.go
+++ b/persist/filesystem_test.go
@@ -17,7 +17,6 @@ package persist_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path"
@@ -37,20 +36,22 @@ func TestFileSystem_Current(t *testing.T) {
 		"./testdata/test2",
 	}
 
+	repo, err := persist.NewDefaultFileSystemRepository("")
+	if err != nil {
+		t.Error(err)
+	}
+	subject := &repo.FileSystem
+
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			subject := persist.FileSystem{Root: tc}
-			resolver := persist.RefSpecResolver{
-				Loader:        persist.DefaultLoader{Fetcher: subject},
-				Brancher:      subject,
-				CurrentReader: subject,
-			}
+			subject.Root = tc
+
 			head, err := subject.Current(context.Background())
 			if err != nil {
 				t.Error(err)
 			}
 
-			headId, err := resolver.Resolve(ctx, head)
+			headId, err := persist.Resolve(ctx, repo, head)
 
 			for i := range headId {
 				if headId[i] != 0 {
@@ -87,37 +88,32 @@ func TestFileSystem_RoundTrip_Current(t *testing.T) {
 		{Amount: envelopes.Balance{"USD": big.NewRat(1729, 1)}},
 	}
 
-	subject := persist.FileSystem{Root: testLocation}
-	writer := persist.DefaultWriter{
-		Stasher: subject,
-	}
-	resolver := persist.RefSpecResolver{
-		Loader:        persist.DefaultLoader{Fetcher: subject},
-		Brancher:      subject,
-		CurrentReader: subject,
+	repo, err := persist.NewDefaultFileSystemRepository(testLocation)
+	if err != nil {
+		t.Error(err)
 	}
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			err := writer.Write(ctx, tc)
+			err := repo.Write(ctx, tc)
 			if err != nil {
 				t.Error(err)
 				return
 			}
 
-			err = subject.WriteCurrent(ctx, tc)
+			err = repo.FileSystem.SetCurrent(ctx, persist.RefSpec(tc.ID().String()))
 			if err != nil {
 				t.Error(err)
 				return
 			}
 
-			refSpec, err := subject.Current(ctx)
+			refSpec, err := repo.Current(ctx)
 			if err != nil {
 				t.Error(err)
 				return
 			}
 
-			got, err := resolver.Resolve(ctx, refSpec)
+			got, err := persist.Resolve(ctx, repo, refSpec)
 			if err != nil {
 				t.Error(err)
 				return
@@ -168,21 +164,22 @@ func TestFileSystem_TransactionRoundTrip(t *testing.T) {
 		}
 	}()
 
-	subject := persist.FileSystem{Root: testDir}
-	writer := persist.DefaultWriter{Stasher: subject}
-	reader := persist.DefaultLoader{Fetcher: subject}
+	repo, err := persist.NewDefaultFileSystemRepository(testDir)
+	if err != nil {
+		t.Error(err)
+	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%T/%s", tc, tc.ID()), func(t *testing.T) {
 
-			err := writer.Write(ctx, tc)
+			err := repo.Write(ctx, tc)
 			if err != nil {
 				t.Error(err)
 				return
 			}
 
 			var loaded envelopes.Transaction
-			err = reader.Load(ctx, tc.ID(), &loaded)
+			err = repo.Load(ctx, tc.ID(), &loaded)
 			if err != nil {
 				t.Error(err)
 				return
@@ -250,218 +247,14 @@ func TestFileSystem_ListBranches(t *testing.T) {
 	}
 }
 
-func TestFileSystem_Clone(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	original := persist.FileSystem{
-		Root: path.Join(".", "testdata", "test3", ".baronial"),
-	}
-	resolver := persist.RefSpecResolver{
-		Loader:        persist.DefaultLoader{Fetcher: original},
-		Brancher:      original,
-		CurrentReader: original,
-	}
-
-	outputLoc, err := ioutil.TempDir("", "envelopesCloneTest")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	t.Logf("Output Location: %s\n", outputLoc)
-
-	subject := persist.FileSystem{
-		Root: outputLoc,
-	}
-
-	head, err := original.Current(ctx)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	headId, err := resolver.Resolve(ctx, head)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	err = subject.Clone(ctx, headId, persist.DefaultBranch, persist.DefaultLoader{Fetcher: original})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	branchCheck, cancelBranchEnumeration := context.WithCancel(ctx)
-	expectedResults := []string{persist.DefaultBranch}
-	results, err := subject.ListBranches(branchCheck)
-	if err != nil {
-		t.Error(err)
-		cancelBranchEnumeration()
-		return
-	}
-
-	encounteredUnexpected := false
-	encountered := 0
-	for entry := range results {
-		encountered++
-		if len(expectedResults) > 0 {
-			if expectedResults[0] != entry {
-				encounteredUnexpected = true
-				t.Fail()
-			}
-		} else {
-			t.Log("extra branches encountered")
-			t.Fail()
-			break
-		}
-	}
-	cancelBranchEnumeration()
-
-	if encounteredUnexpected {
-		t.Logf("Unexpected branch results encountered")
-	}
-	if encountered < len(expectedResults) {
-		t.Logf("Too few branches encountered")
-		t.Fail()
-	}
-}
-
-func TestFileSystem_WriteCurrent(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Run("from-scratch", testFileSystem_WriteCurrentFromScratch(ctx))
-}
-
-func testFileSystem_WriteCurrentFromScratch(ctx context.Context) func(t *testing.T) {
-	return func(t *testing.T) {
-		tempDir, err := ioutil.TempDir("", "")
-		if err != nil {
-			t.Error(err)
-			return
-		}
-
-		t.Logf("Repo Location: %s", tempDir)
-
-		subject := persist.FileSystem{
-			Root: tempDir,
-		}
-		resolver := persist.RefSpecResolver{
-			Loader:        persist.DefaultLoader{Fetcher: subject},
-			Brancher:      subject,
-			CurrentReader: subject,
-		}
-
-		firstTransaction := envelopes.Transaction{
-			Merchant:   "Aer Lingus",
-			ActualTime: time.Now(),
-			Comment:    "foo",
-			Committer: envelopes.User{
-				FullName: "Martin Strobel",
-				Email:    "martin.strobel@live.com",
-			},
-		}
-
-		err = subject.WriteBranch(ctx, persist.DefaultBranch, firstTransaction.ID())
-		if err != nil {
-			t.Error(err)
-			return
-		}
-
-		err = subject.SetCurrent(ctx, persist.DefaultBranch)
-		if err != nil {
-			t.Error(err)
-			return
-		}
-
-		err = subject.WriteCurrent(ctx, firstTransaction)
-		if err != nil {
-			t.Error(err)
-			return
-		}
-
-		actualRef, err := subject.Current(ctx)
-		if err != nil {
-			t.Error(err)
-			return
-		}
-		if actualRef != persist.DefaultBranch {
-			t.Logf("Unexpected RefSpec!\n\twant:\t%q\n\tgot: \t%q", persist.DefaultBranch, actualRef)
-			t.Fail()
-		}
-
-		want := firstTransaction.ID()
-		got, err := subject.Current(ctx)
-		if err != nil {
-			t.Error(err)
-			return
-		}
-
-		gotId, err := resolver.Resolve(ctx, got)
-		if err != nil {
-			t.Error(err)
-			return
-		}
-
-		if !gotId.Equal(want) {
-			t.Logf("Unexpected Transaction ID!\n\twant:\t%q\n\tgot: \t%q", gotId.String(), want.String())
-			t.Fail()
-		}
-	}
-}
-
-func BenchmarkFileSystem_CloneSmall(b *testing.B) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	original := persist.FileSystem{
-		Root: path.Join(".", "testdata", "test3", ".baronial"),
-	}
-	resolver := persist.RefSpecResolver{
-		Loader:        persist.DefaultLoader{Fetcher: original},
-		Brancher:      original,
-		CurrentReader: original,
-	}
-	head, err := original.Current(ctx)
-	if err != nil {
-		b.Error(err)
-		return
-	}
-	headId, err := resolver.Resolve(ctx, head)
-	if err != nil {
-		b.Error(err)
-		return
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		outputLoc, err := ioutil.TempDir("", "cloneSmallBenchmark")
-		if err != nil {
-			b.Error(err)
-			return
-		}
-
-		subject := persist.FileSystem{
-			Root: outputLoc,
-		}
-
-		b.StartTimer()
-		err = subject.Clone(ctx, headId, persist.DefaultBranch, persist.DefaultLoader{Fetcher: original})
-		if err != nil {
-			b.Error(err)
-			return
-		}
-	}
-}
-
 func BenchmarkFileSystem_RoundTrip(b *testing.B) {
 	benchDir := path.Join("testdata", "bench", "filesystem", "roundtrip")
-	subject := persist.FileSystem{Root: benchDir}
-	writer := persist.DefaultWriter{Stasher: subject}
-	reader := persist.DefaultLoader{Fetcher: subject}
-	err := os.MkdirAll(benchDir, os.ModePerm)
+	repo, err := persist.NewDefaultFileSystemRepository(benchDir)
+	if err != nil {
+		b.Error(err)
+	}
+
+	err = os.MkdirAll(benchDir, os.ModePerm)
 	if err != nil {
 		b.Log(err)
 		b.FailNow()
@@ -476,13 +269,13 @@ func BenchmarkFileSystem_RoundTrip(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		currentBudget := envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(int64(i), 1)}}
-		err = writer.Write(context.Background(), currentBudget)
+		err = repo.Write(context.Background(), currentBudget)
 		if err != nil {
 			b.Error(err)
 			return
 		}
 		var loaded envelopes.Budget
-		err = reader.Load(context.Background(), currentBudget.ID(), &loaded)
+		err = repo.Load(context.Background(), currentBudget.ID(), &loaded)
 		if err != nil {
 			b.Error(err)
 			return

--- a/persist/refspec_test.go
+++ b/persist/refspec_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/marstr/envelopes"
 )
 
-func TestRefSpecResolver_Resolve(t *testing.T) {
+func Test_Resolve(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -55,18 +55,22 @@ func TestRefSpecResolver_Resolve(t *testing.T) {
 
 	fs := &FileSystem{}
 
-	resolver := RefSpecResolver{
-		Loader: DefaultLoader{
-			Fetcher: fs,
-		},
-		Brancher:      fs,
+	loader := struct{
+		Loader
+		CurrentReader
+		BranchReader
+		BranchLister
+	}{
+		Loader: &DefaultLoader{Fetcher: fs},
 		CurrentReader: fs,
+		BranchLister: fs,
+		BranchReader: fs,
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s-%q", tc.repoLocation, string(tc.subject)), func(t *testing.T) {
 			fs.Root = tc.repoLocation
-			got, err := resolver.Resolve(ctx, tc.subject)
+			got, err := Resolve(ctx, loader, tc.subject)
 			if err != nil {
 				t.Error(err)
 				return

--- a/persist/repository.go
+++ b/persist/repository.go
@@ -43,16 +43,19 @@ type BareRepositoryReaderWriter interface {
 	BareRepositoryWriter
 }
 
+// RepositoryReader indicates that a structs has all the functionality of a BareRepositoryReader, plus a CurrentReader.
 type RepositoryReader interface {
 	BareRepositoryReader
 	CurrentReader
 }
 
+// RepositoryWriter has all the functionality of a BareRepositoryWriter, plus the ability to update Current.
 type RepositoryWriter interface {
 	BareRepositoryWriter
 	CurrentWriter
 }
 
+// RepositoryReaderWriter has all the functionality of a RepositoryReader and RepositoryWriter.
 type RepositoryReaderWriter interface {
 	RepositoryReader
 	RepositoryWriter

--- a/persist/repository.go
+++ b/persist/repository.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright {YEAR} Martin Strobel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package persist
+
+import (
+	"context"
+
+	"github.com/marstr/envelopes"
+)
+
+// BareRepositoryReader indicates that a struct is able to read objects like envelopes.Budget, envelopes.Transaction,
+// and branch instances from a repository. However, it does not indicate that the repository has a current working copy.
+type BareRepositoryReader interface {
+	Loader
+	BranchReader
+	BranchLister
+}
+
+// BareRepositoryWriter indicates that a struct is able to add objects like envelopes.Budget, envelopes.Transaction,
+// and branch instances to a repository. However, it does not indicate that the repository has a current working copy.
+type BareRepositoryWriter interface {
+	Writer
+	BranchWriter
+}
+
+// BareRepositoryReaderWriter indicates that a struct has the ability to both read and write
+type BareRepositoryReaderWriter interface {
+	BareRepositoryReader
+	BareRepositoryWriter
+}
+
+type RepositoryReader interface {
+	BareRepositoryReader
+	CurrentReader
+}
+
+type RepositoryWriter interface {
+	BareRepositoryWriter
+	CurrentWriter
+}
+
+type RepositoryReaderWriter interface {
+	RepositoryReader
+	RepositoryWriter
+}
+
+// Commitb adds an envelopes.Transaction as the most recent commit on a branch. Whatever parent belongs to `t` will be
+// overwritten by this operation before the write.
+func Commitb(ctx context.Context, repo BareRepositoryReaderWriter, t envelopes.Transaction, branch string) error {
+	var err error
+	t.Parent, err = repo.ReadBranch(ctx, branch)
+	if err != nil {
+		return err
+	}
+
+	err = repo.Write(ctx, t)
+	if err != nil {
+		return err
+	}
+
+	return repo.WriteBranch(ctx, branch, t.ID())
+}


### PR DESCRIPTION
Many pieces of functionality take a collection of today's interfaces to do their job, while many times that functionality is provided by the same object. This lead to awkwardness, like RefSpecResolver types that were initialized with a bunch of copies of the same object.

While some of these interfaces represent a lot of methods that need to be implemented, which does tend to weaken the abstraction, it is still desirable to use the lowest-level of interface available. If you only need a `persist.Loader`, only call for a `persist.Loader`. The newly published interfaces seek to provide at least some very commonly needed bundles of functionality to ease some awkwardness.