### PR TITLE
Add a Clone function that is agnostic to the Loader/Writer it is using.

### DIFF
--- a/persist/mock_repository_test.go
+++ b/persist/mock_repository_test.go
@@ -53,7 +53,7 @@ func (mb MockRepository) WriteBranch(_ context.Context, name string, id envelope
 func (mb MockRepository) ListBranches(ctx context.Context) (<-chan string, error) {
 	retval := make(chan string)
 
-	func() {
+	go func() {
 		defer close(retval)
 		for k := range mb.branches {
 			select {

--- a/persist/repository_test.go
+++ b/persist/repository_test.go
@@ -1,0 +1,82 @@
+package persist
+
+import (
+	"context"
+	"github.com/marstr/envelopes"
+	"testing"
+)
+
+func TestBareClone(t *testing.T) {
+	//ctx, cancel := context.WithTimeout(context.Background(), 90 * time.Second)
+	// defer cancel()
+	ctx := context.Background()
+
+	t.Run("linear", testBareCloneLinear(ctx))
+}
+
+func testBareCloneLinear(ctx context.Context) func(*testing.T) {
+	return func(t *testing.T) {
+		const transactionCount = 4
+		const branchCount = 1
+		src := NewMockRepository(branchCount, transactionCount)
+		expected := make(map[envelopes.ID]envelopes.Transaction)
+
+		a := envelopes.Transaction{Comment: "Deepest"}
+		if err := src.Write(ctx, a); err != nil {
+			t.Error(err)
+		}
+
+		b := envelopes.Transaction{Comment: "Deeper", Parents: []envelopes.ID{a.ID()}}
+		if err := src.Write(ctx, b); err != nil {
+			t.Error(err)
+		}
+		expected[b.Parents[0]] = a
+
+		c := envelopes.Transaction{Comment: "Deep", Parents: []envelopes.ID{b.ID()}}
+		if err := src.Write(ctx, c); err != nil {
+			t.Error(err)
+		}
+		expected[c.Parents[0]] = b
+
+		d := envelopes.Transaction{Comment: "Shallow", Parents: []envelopes.ID{c.ID()}}
+		if err := src.Write(ctx, d); err != nil {
+			t.Error(err)
+		}
+		expected[d.Parents[0]] = c
+		dId := d.ID()
+		expected[dId] = d
+		if err := src.WriteBranch(ctx, DefaultBranch, dId); err != nil {
+			t.Error(err)
+			return
+		}
+
+		dest := NewMockRepository(branchCount, transactionCount)
+
+		if err := BareClone(ctx, src, dest); err != nil {
+			t.Error(err)
+			return
+		}
+
+		destBranchList, err := dest.ListBranches(ctx)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		for foundBranch := range destBranchList {
+			t.Logf("Found a branch! %q", foundBranch)
+		}
+
+		for id, want := range expected {
+			var got envelopes.Transaction
+			err = dest.Load(ctx, id, &got)
+			if err != nil {
+				t.Error(err)
+				continue
+			}
+
+			if !got.Equal(want) {
+				t.Errorf("Transaction %s did not match expected", id)
+			}
+		}
+	}
+}

--- a/persist/repository_test.go
+++ b/persist/repository_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"github.com/marstr/envelopes"
 	"testing"
+	"time"
 )
 
 func TestBareClone(t *testing.T) {
-	//ctx, cancel := context.WithTimeout(context.Background(), 90 * time.Second)
-	// defer cancel()
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 90 * time.Second)
+	defer cancel()
 
 	t.Run("linear", testBareCloneLinear(ctx))
 	t.Run("diamond", testBareCloneDiamond(ctx))

--- a/persist/walker.go
+++ b/persist/walker.go
@@ -1,12 +1,11 @@
 // "Money talks, bullshit walks" -Unknown
 
-package traverse
+package persist
 
 import (
 	"context"
 	"github.com/marstr/collection"
 	"github.com/marstr/envelopes"
-	"github.com/marstr/envelopes/persist"
 )
 
 type WalkFunc func(ctx context.Context, transaction envelopes.Transaction) error
@@ -21,7 +20,7 @@ func (err ErrSkipAncestors) Error() string {
 }
 
 type Walker struct {
-	Loader persist.Loader
+	Loader Loader
 }
 
 func (w *Walker) Walk(ctx context.Context, action WalkFunc, heads ...envelopes.ID) error {

--- a/persist/walker_test.go
+++ b/persist/walker_test.go
@@ -1,9 +1,8 @@
-package traverse
+package persist
 
 import (
 	"context"
 	"github.com/marstr/envelopes"
-	"github.com/marstr/envelopes/persist"
 	"testing"
 )
 
@@ -15,7 +14,7 @@ func TestWalker_Walk(t *testing.T) {
 }
 
 func chain(ctx context.Context) func(t *testing.T) {
-	cache := persist.NewCache(2)
+	cache := NewCache(2)
 	a := envelopes.Transaction{
 		Comment: "First!",
 	}
@@ -69,7 +68,7 @@ func chain(ctx context.Context) func(t *testing.T) {
 }
 
 func fork(ctx context.Context) func(t *testing.T) {
-	cache := persist.NewCache(3)
+	cache := NewCache(3)
 	a := envelopes.Transaction{
 		Comment: "First!",
 	}
@@ -139,7 +138,7 @@ func fork(ctx context.Context) func(t *testing.T) {
 }
 
 func respectSkipAncestors(ctx context.Context) func(t *testing.T) {
-	cache := persist.NewCache(4)
+	cache := NewCache(4)
 	a := envelopes.Transaction{
 		Comment: "First!",
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -54,6 +54,59 @@ func (t Transaction) String() string {
 	return string(marshaled)
 }
 
+// Equal determines whether two instances of Transaction share identical values.
+func (t Transaction) Equal(other Transaction) bool {
+	if t.State == nil && other.State != nil {
+		return false
+	} else if !t.State.Equal(*other.State) {
+		return false
+	}
+
+	if !t.ActualTime.Equal(other.ActualTime) {
+		return false
+	}
+
+	if !t.PostedTime.Equal(other.PostedTime) {
+		return false
+	}
+
+	if !t.EnteredTime.Equal(other.EnteredTime) {
+		return false
+	}
+
+	if !t.Amount.Equal(other.Amount) {
+		return false
+	}
+
+	if t.Merchant != other.Merchant {
+		return false
+	}
+
+	if !t.Committer.Equal(other.Committer) {
+		return false
+	}
+
+	if t.Comment != other.Comment {
+		return false
+	}
+
+	if t.RecordID != other.RecordID {
+		return false
+	}
+
+	if len(t.Parents) != len(other.Parents) {
+		return false
+	}
+
+	for i := range t.Parents {
+		if !t.Parents[i].Equal(other.Parents[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MarshalText computes a string which uniquely represents this Transaction.
 func (t Transaction) MarshalText() ([]byte, error) {
 	const timeFormat = time.RFC3339

--- a/transaction.go
+++ b/transaction.go
@@ -58,6 +58,8 @@ func (t Transaction) String() string {
 func (t Transaction) Equal(other Transaction) bool {
 	if t.State == nil && other.State != nil {
 		return false
+	} else if t.State == nil && other.State == nil {
+		// Intentionally Left Blank
 	} else if !t.State.Equal(*other.State) {
 		return false
 	}

--- a/user.go
+++ b/user.go
@@ -51,3 +51,7 @@ func (u User) String() string {
 	}
 	return string(result)
 }
+
+func (u User) Equal(other User) bool {
+	return u.FullName == other.FullName && u.Email == other.Email
+}


### PR DESCRIPTION
The previous Clone function was dangled impetuously on the `FileSystem` type, basically on the assumption that it would be great to be passed just a Loader. That was pretty dumb though, because each type of Stasher shouldn't need to rewrite the overall Clone logic. Associating it instead with the Repository interfaces makes way more sense.