### PR TITLE
Adding id to persist.WalkFunc

### DIFF
--- a/persist/repository.go
+++ b/persist/repository.go
@@ -111,7 +111,7 @@ func bareClone(ctx context.Context, src BareRepositoryReader, dest BareRepositor
 		Loader: src,
 	}
 
-	return walker.Walk(ctx, func(ctx context.Context, transaction envelopes.Transaction) error {
+	return walker.Walk(ctx, func(ctx context.Context, _ envelopes.ID, transaction envelopes.Transaction) error {
 		return dest.Write(ctx, transaction)
 	}, heads...)
 }

--- a/persist/repository_test.go
+++ b/persist/repository_test.go
@@ -207,8 +207,8 @@ func bareRepositoriesEqual(ctx context.Context, left, right BareRepositoryReader
 	// Walk through all transactions in the left repository, and make sure they're all present in the right repository.
 	walker := Walker{Loader: left}
 	var current envelopes.Transaction
-	err = walker.Walk(ctx, func(ctx context.Context, transaction envelopes.Transaction) error {
-		err = right.Load(ctx, transaction.ID(), &current)
+	err = walker.Walk(ctx, func(ctx context.Context, id envelopes.ID, transaction envelopes.Transaction) error {
+		err = right.Load(ctx, id, &current)
 		if err != nil {
 			return err
 		}
@@ -220,8 +220,8 @@ func bareRepositoriesEqual(ctx context.Context, left, right BareRepositoryReader
 
 	// Walk through all transactions in the right repository, and make sure they're all present in the left repository.
 	walker.Loader = right
-	err = walker.Walk(ctx, func(ctx context.Context, transaction envelopes.Transaction) error {
-		err = left.Load(ctx, transaction.ID(), &current)
+	err = walker.Walk(ctx, func(ctx context.Context, id envelopes.ID, transaction envelopes.Transaction) error {
+		err = left.Load(ctx, id, &current)
 		if err != nil {
 			return err
 		}

--- a/persist/walker.go
+++ b/persist/walker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/marstr/envelopes"
 )
 
-type WalkFunc func(ctx context.Context, transaction envelopes.Transaction) error
+type WalkFunc func(ctx context.Context, id envelopes.ID, transaction envelopes.Transaction) error
 
 // ErrSkipAncestors allows a WalkFunc to communicate that parents of this transaction shouldn't be visited.
 // If other Transactions have shared parent, but don't return ErrSkipAncestors, the shared parents will still
@@ -52,7 +52,7 @@ func (w *Walker) Walk(ctx context.Context, action WalkFunc, heads ...envelopes.I
 		}
 		processed[currentId] = struct{}{}
 
-		err = action(ctx, current)
+		err = action(ctx, currentId, current)
 		if err != nil {
 			switch err.(type) {
 			case ErrSkipAncestors:

--- a/persist/walker_test.go
+++ b/persist/walker_test.go
@@ -46,8 +46,7 @@ func chain(ctx context.Context) func(t *testing.T) {
 			Loader: cache,
 		}
 
-		err := texasRanger.Walk(ctx, func(ctx context.Context, transaction envelopes.Transaction) error {
-			currentId := transaction.ID()
+		err := texasRanger.Walk(ctx, func(ctx context.Context, currentId envelopes.ID, transaction envelopes.Transaction) error {
 			_, ok := expected[currentId]
 			if ok {
 				delete(expected, currentId)
@@ -116,8 +115,7 @@ func fork(ctx context.Context) func(t *testing.T) {
 			Loader: cache,
 		}
 
-		err := texasRanger.Walk(ctx, func(ctx context.Context, transaction envelopes.Transaction) error {
-			currentId := transaction.ID()
+		err := texasRanger.Walk(ctx, func(ctx context.Context, currentId envelopes.ID, transaction envelopes.Transaction) error {
 			_, ok := expected[currentId]
 			if ok {
 				delete(expected, currentId)
@@ -198,8 +196,7 @@ func respectSkipAncestors(ctx context.Context) func(t *testing.T) {
 			Loader: cache,
 		}
 
-		err := texasRanger.Walk(ctx, func(ctx context.Context, transaction envelopes.Transaction) error {
-			currentId := transaction.ID()
+		err := texasRanger.Walk(ctx, func(ctx context.Context, currentId envelopes.ID, transaction envelopes.Transaction) error {
 			_, ok := expected[currentId]
 
 			if ok {


### PR DESCRIPTION
This will seriously reduce the number of times it needs to be computed by Loaders and Writers, etc.

Fixes #42 