### PR TITLE
Remove `io/ioutil` References

### DIFF
--- a/persist/filesystem/config.json
+++ b/persist/filesystem/config.json
@@ -1,1 +1,0 @@
-{"objects":{"format":"json","version":2},"objectLocs":1,"branches":{"format":"","version":0}}

--- a/persist/filesystem/config.json
+++ b/persist/filesystem/config.json
@@ -1,0 +1,1 @@
+{"objects":{"format":"json","version":2},"objectLocs":1,"branches":{"format":"","version":0}}

--- a/persist/filesystem/filesystem.go
+++ b/persist/filesystem/filesystem.go
@@ -20,17 +20,15 @@ package filesystem
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/marstr/collection/v2"
-
 	"github.com/marstr/envelopes"
 	"github.com/marstr/envelopes/persist"
 
+	"github.com/marstr/collection/v2"
 	"github.com/mitchellh/go-homedir"
 )
 
@@ -58,7 +56,7 @@ func (fs FileSystem) Current(_ context.Context) (result persist.RefSpec, err err
 		return
 	}
 
-	raw, err := ioutil.ReadFile(p)
+	raw, err := os.ReadFile(p)
 	if err != nil {
 		return
 	}
@@ -75,7 +73,7 @@ func (fs FileSystem) SetCurrent(_ context.Context, current persist.RefSpec) erro
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(p, []byte(current), fs.getCreatePermissions())
+	return os.WriteFile(p, []byte(current), fs.getCreatePermissions())
 }
 
 // Fetch is able to read into memory the marshaled form of a Budget related object.
@@ -87,7 +85,7 @@ func (fs FileSystem) Fetch(_ context.Context, id envelopes.ID) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadFile(p)
+	return os.ReadFile(p)
 }
 
 // Stash commits the provided payload to disk at a place that it can retreive again if asked for the ID specified here.

--- a/persist/filesystem/filesystem_bank_record_id_index.go
+++ b/persist/filesystem/filesystem_bank_record_id_index.go
@@ -19,12 +19,12 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/marstr/envelopes/persist"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/marstr/envelopes"
+	"github.com/marstr/envelopes/persist"
 )
 
 type ErrEmptyBankRecordID struct{}

--- a/persist/filesystem/filesystem_bank_record_id_index_test.go
+++ b/persist/filesystem/filesystem_bank_record_id_index_test.go
@@ -1,7 +1,6 @@
 package filesystem
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -30,7 +29,7 @@ func Test_segmentNormalizedName(t *testing.T) {
 
 func TestFilesystemBankRecordIDIndex_AppendBankRecordID(t *testing.T) {
 	bankRecordId := envelopes.BankRecordID("20201212 575073 2,000 202,012,128,756")
-	tempDir, err := ioutil.TempDir("", "bankRecordID_index_test")
+	tempDir, err := os.MkdirTemp("", "bankRecordID_index_test")
 	if err != nil {
 		t.Error(err)
 		return
@@ -110,7 +109,7 @@ func TestFilesystemBankRecordIDIndex_AppendBankRecordID(t *testing.T) {
 
 func TestFilesystemBankRecordIDIndex_WriteBankRecordID(t *testing.T) {
 	bankRecordId := envelopes.BankRecordID("20201212 575073 2,000 202,012,128,756")
-	tempDir, err := ioutil.TempDir("", "bankRecordID_index_test")
+	tempDir, err := os.MkdirTemp("", "bankRecordID_index_test")
 	if err != nil {
 		t.Error(err)
 		return

--- a/persist/filesystem/filesystem_test.go
+++ b/persist/filesystem/filesystem_test.go
@@ -17,7 +17,6 @@ package filesystem_test
 import (
 	"context"
 	"fmt"
-	"github.com/marstr/envelopes/persist/filesystem"
 	"math/big"
 	"os"
 	"path"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/marstr/envelopes"
 	"github.com/marstr/envelopes/persist"
+	"github.com/marstr/envelopes/persist/filesystem"
 )
 
 func TestFileSystem_Current(t *testing.T) {
@@ -53,6 +53,9 @@ func TestFileSystem_Current(t *testing.T) {
 			}
 
 			headId, err := persist.Resolve(ctx, repo, head)
+			if err != nil {
+				t.Error(err)
+			}
 
 			for i := range headId {
 				if headId[i] != 0 {
@@ -247,8 +250,6 @@ func TestFileSystem_ListBranches(t *testing.T) {
 		})
 	}
 }
-
-
 
 func BenchmarkFileSystem_RoundTrip(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/persist/filesystem/loader_v2_test.go
+++ b/persist/filesystem/loader_v2_test.go
@@ -2,7 +2,6 @@ package filesystem
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -17,7 +16,7 @@ func TestLoadAncestor(t *testing.T) {
 	// ctx, cancel := context.Background(), context.CancelFunc(func() {})
 	defer cancel()
 
-	test_loc, err := ioutil.TempDir("", "envelopes_TestLoadAncestor_")
+	test_loc, err := os.MkdirTemp("", "envelopes_TestLoadAncestor_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -97,7 +96,6 @@ func TestLoadAncestor(t *testing.T) {
 		}
 	}
 }
-
 
 func TestCache_Load_reuseHits(t *testing.T) {
 	var err error

--- a/persist/filesystem/repository.go
+++ b/persist/filesystem/repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -202,7 +201,7 @@ func openRepository(ctx context.Context, loc string, cache *persist.Cache, optio
 func LoadConfig(_ context.Context, loc string) (*RepositoryConfig, error) {
 	var err error
 	var configContents []byte
-	configContents, err = ioutil.ReadFile(path.Join(loc, ConfigFilename))
+	configContents, err = os.ReadFile(path.Join(loc, ConfigFilename))
 	if os.IsNotExist(err) {
 		return &missingConfiguration, nil
 	} else if err != nil {
@@ -224,5 +223,5 @@ func writeConfig(_ context.Context, loc string, config *RepositoryConfig, mode o
 		return err
 	}
 
-	return ioutil.WriteFile(path.Join(loc, ConfigFilename), marshaled, mode)
+	return os.WriteFile(path.Join(loc, ConfigFilename), marshaled, mode)
 }

--- a/persist/json/models_v2_test.go
+++ b/persist/json/models_v2_test.go
@@ -3,7 +3,6 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -115,7 +114,7 @@ func Test_StateRoundtrip(t *testing.T) {
 		},
 	}
 
-	tempLocation, err := ioutil.TempDir("", "envelopes_id_tests")
+	tempLocation, err := os.MkdirTemp("", "envelopes_id_tests")
 	if err != nil {
 		t.Errorf("unable to create test location")
 		return
@@ -173,4 +172,3 @@ func (md mockDisk) Fetch(_ context.Context, id envelopes.ID) ([]byte, error) {
 	}
 	return []byte{}, persist.ErrObjectNotFound(id)
 }
-


### PR DESCRIPTION
This was deprecated many Go versions ago. It's not causing any problems, but these references mask current best practices that should be adopted moving forward, and makes potential newer APIs more discoverable as they're added.