### PR TITLE
Refactor `persist.Loader` and `persist.Writer` to not use type discrimination

### DIFF
--- a/persist/cache.go
+++ b/persist/cache.go
@@ -78,23 +78,92 @@ func (c Cache) WriteAccounts(ctx context.Context, subject envelopes.Accounts) er
 	return c.Writer.WriteAccounts(ctx, subject)
 }
 
-// Load copies the desired object from the Cache into destination. If the requested option is present in the cache, it
-// doesn't invoke Loader. If it is not present, and Loader is not nil, it invokes Loader and adds the result to the
-// cache.
-func (c Cache) Load(ctx context.Context, subject envelopes.ID, destination envelopes.IDer) error {
+// LoadTransaction copies the desired object from the Cache into destination. If the requested option is present in the
+// cache, it doesn't invoke Loader. If it is not present, and Loader is not nil, it invokes Loader and adds the result
+// to the cache.
+func (c Cache) LoadTransaction(ctx context.Context, subject envelopes.ID, destination *envelopes.Transaction) error {
 	cached, ok := c.lruCache.Get(subject)
 	if !ok {
-		return c.miss(ctx, subject, destination)
+		return c.missTransaction(ctx, subject, destination)
 	}
 	return c.hit(ctx, cached, destination)
 }
 
-func (c Cache) miss(ctx context.Context, subject envelopes.ID, destination envelopes.IDer) error {
+func (c Cache) missTransaction(ctx context.Context, subject envelopes.ID, destination *envelopes.Transaction) error {
 	if c.Loader == nil {
 		return ErrObjectNotFound(subject)
 	}
 
-	err := c.Loader.Load(ctx, subject, destination)
+	err := c.Loader.LoadTransaction(ctx, subject, destination)
+	if err == nil {
+		c.lruCache.Put(subject, destination)
+	}
+	return err
+}
+
+// LoadState copies the desired object from the Cache into destination. If the requested option is present in the
+// cache, it doesn't invoke Loader. If it is not present, and Loader is not nil, it invokes Loader and adds the result
+// to the cache.
+func (c Cache) LoadState(ctx context.Context, subject envelopes.ID, destination *envelopes.State) error {
+	cached, ok := c.lruCache.Get(subject)
+	if !ok {
+		return c.missState(ctx, subject, destination)
+	}
+	return c.hit(ctx, cached, destination)
+}
+
+func (c Cache) missState(ctx context.Context, subject envelopes.ID, destination *envelopes.State) error {
+	if c.Loader == nil {
+		return ErrObjectNotFound(subject)
+	}
+
+	err := c.Loader.LoadState(ctx, subject, destination)
+	if err == nil {
+		c.lruCache.Put(subject, destination)
+	}
+	return err
+}
+
+// LoadBudget copies the desired object from the Cache into destination. If the requested option is present in the
+// cache, it doesn't invoke Loader. If it is not present, and Loader is not nil, it invokes Loader and adds the result
+// to the cache.
+func (c Cache) LoadBudget(ctx context.Context, subject envelopes.ID, destination *envelopes.Budget) error {
+	cached, ok := c.lruCache.Get(subject)
+	if !ok {
+		return c.missBudget(ctx, subject, destination)
+	}
+	return c.hit(ctx, cached, destination)
+}
+
+func (c Cache) missBudget(ctx context.Context, subject envelopes.ID, destination *envelopes.Budget) error {
+	if c.Loader == nil {
+		return ErrObjectNotFound(subject)
+	}
+
+	err := c.Loader.LoadBudget(ctx, subject, destination)
+	if err == nil {
+		c.lruCache.Put(subject, destination)
+	}
+	return err
+}
+
+// LoadAccounts copies the desired object from the Cache into destination. If the requested option is present in the
+// cache, it doesn't invoke Loader. If it is not present, and Loader is not nil, it invokes Loader and adds the result
+// to the cache.
+func (c Cache) LoadAccounts(ctx context.Context, subject envelopes.ID, destination *envelopes.Accounts) error {
+	cached, ok := c.lruCache.Get(subject)
+	if !ok {
+		return c.missAccounts(ctx, subject, destination)
+	}
+	return c.hit(ctx, cached, destination)
+}
+
+func (c Cache) missAccounts(ctx context.Context, subject envelopes.ID, destination *envelopes.Accounts) error {
+	if c.Loader == nil {
+		return ErrObjectNotFound(subject)
+	}
+
+	err := c.Loader.LoadAccounts(ctx, subject, destination)
 	if err == nil {
 		c.lruCache.Put(subject, destination)
 	}

--- a/persist/cache.go
+++ b/persist/cache.go
@@ -3,9 +3,11 @@ package persist
 import (
 	"context"
 	"fmt"
-	"github.com/marstr/collection/v2"
-	"github.com/marstr/envelopes"
 	"reflect"
+
+	"github.com/marstr/envelopes"
+
+	"github.com/marstr/collection/v2"
 )
 
 // ErrTypeMismatch is when an
@@ -40,31 +42,40 @@ func NewCache(capacity uint) *Cache {
 	}
 }
 
-// Write adds an IDer to this cache. If Writer isn't nil, it is immediately invoked.
-func (c Cache) Write(ctx context.Context, subject envelopes.IDer) error {
-	// Ensure we cache a pointer, and not a copy of the object.
-	switch subject.(type) {
-	case envelopes.Transaction:
-		cast := subject.(envelopes.Transaction)
-		subject = &cast
-	case envelopes.State:
-		cast := subject.(envelopes.State)
-		subject = &cast
-	case envelopes.Budget:
-		cast := subject.(envelopes.Budget)
-		subject = &cast
-	case envelopes.Accounts:
-		cast := subject.(envelopes.Accounts)
-		subject = &cast
-	}
-
-	c.lruCache.Put(subject.ID(), subject)
-
+// WriteTransaction adds a Transaction to this cache. If Writer isn't nil, it is immediately invoked.
+func (c Cache) WriteTransaction(ctx context.Context, subject envelopes.Transaction) error {
+	c.lruCache.Put(subject.ID(), &subject)
 	if c.Writer == nil {
 		return nil
 	}
+	return c.Writer.WriteTransaction(ctx, subject)
+}
 
-	return c.Writer.Write(ctx, subject)
+// WriteState adds a State to this cache. If Writer isn't nil, it is immediately invoked.
+func (c Cache) WriteState(ctx context.Context, subject envelopes.State) error {
+	c.lruCache.Put(subject.ID(), &subject)
+	if c.Writer == nil {
+		return nil
+	}
+	return c.Writer.WriteState(ctx, subject)
+}
+
+// WriteBudget adds a Budget to this cache. If Writer isn't nil, it is immediately invoked.
+func (c Cache) WriteBudget(ctx context.Context, subject envelopes.Budget) error {
+	c.lruCache.Put(subject.ID(), &subject)
+	if c.Writer == nil {
+		return nil
+	}
+	return c.Writer.WriteBudget(ctx, subject)
+}
+
+// WriteAccounts adds an instance of Accounts to this cache. If Writer isn't nil, it is immediately invoked.
+func (c Cache) WriteAccounts(ctx context.Context, subject envelopes.Accounts) error {
+	c.lruCache.Put(subject.ID(), subject)
+	if c.Writer == nil {
+		return nil
+	}
+	return c.Writer.WriteAccounts(ctx, subject)
 }
 
 // Load copies the desired object from the Cache into destination. If the requested option is present in the cache, it

--- a/persist/cache_test.go
+++ b/persist/cache_test.go
@@ -2,21 +2,22 @@ package persist
 
 import (
 	"context"
-	"github.com/marstr/envelopes"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/marstr/envelopes"
 )
 
 func TestCache_Load(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 90 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	t.Run("UsePassThroughOnMiss", testUsePassThroughOnMiss(ctx))
 }
 
 func testUsePassThroughOnMiss(ctx context.Context) func(t *testing.T) {
-	return func (t * testing.T) {
+	return func(t *testing.T) {
 		want := envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{"MSFT": big.NewRat(24, 1)},
@@ -27,7 +28,7 @@ func testUsePassThroughOnMiss(ctx context.Context) func(t *testing.T) {
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
-				"brokerage": envelopes.Balance{
+				"brokerage": {
 					"MSFT": big.NewRat(24, 1),
 					"TMUS": big.NewRat(35, 1),
 				},
@@ -35,7 +36,7 @@ func testUsePassThroughOnMiss(ctx context.Context) func(t *testing.T) {
 		}
 
 		passThrough := NewCache(10)
-		if err := passThrough.Write(ctx, want); err != nil {
+		if err := passThrough.WriteState(ctx, want); err != nil {
 			t.Error(err)
 			return
 		}

--- a/persist/cache_test.go
+++ b/persist/cache_test.go
@@ -45,7 +45,7 @@ func testUsePassThroughOnMiss(ctx context.Context) func(t *testing.T) {
 		subject.Loader = passThrough
 
 		var got envelopes.State
-		err := subject.Load(ctx, want.ID(), &got)
+		err := subject.LoadState(ctx, want.ID(), &got)
 		if err != nil {
 			t.Error(err)
 			return

--- a/persist/filesystem/filesystem_test.go
+++ b/persist/filesystem/filesystem_test.go
@@ -183,7 +183,7 @@ func TestFileSystem_TransactionRoundTrip(t *testing.T) {
 			}
 
 			var loaded envelopes.Transaction
-			err = repo.Load(ctx, tc.ID(), &loaded)
+			err = repo.LoadTransaction(ctx, tc.ID(), &loaded)
 			if err != nil {
 				t.Error(err)
 				return
@@ -282,7 +282,7 @@ func BenchmarkFileSystem_RoundTrip(b *testing.B) {
 			return
 		}
 		var loaded envelopes.Budget
-		err = repo.Load(context.Background(), currentBudget.ID(), &loaded)
+		err = repo.LoadBudget(context.Background(), currentBudget.ID(), &loaded)
 		if err != nil {
 			b.Error(err)
 			return

--- a/persist/filesystem/filesystem_test.go
+++ b/persist/filesystem/filesystem_test.go
@@ -99,7 +99,7 @@ func TestFileSystem_RoundTrip_Current(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			err := repo.Write(ctx, tc)
+			err := repo.WriteTransaction(ctx, tc)
 			if err != nil {
 				t.Error(err)
 				return
@@ -176,7 +176,7 @@ func TestFileSystem_TransactionRoundTrip(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%T/%s", tc, tc.ID()), func(t *testing.T) {
 
-			err := repo.Write(ctx, tc)
+			err := repo.WriteTransaction(ctx, tc)
 			if err != nil {
 				t.Error(err)
 				return
@@ -276,7 +276,7 @@ func BenchmarkFileSystem_RoundTrip(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		currentBudget := envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(int64(i), 1)}}
-		err = repo.Write(context.Background(), currentBudget)
+		err = repo.WriteBudget(context.Background(), currentBudget)
 		if err != nil {
 			b.Error(err)
 			return

--- a/persist/filesystem/loader_v2_test.go
+++ b/persist/filesystem/loader_v2_test.go
@@ -51,9 +51,9 @@ func TestLoadAncestor(t *testing.T) {
 		return
 	}
 
-	toWrite := []*envelopes.Transaction{&t1, &t2, &t3}
+	toWrite := []envelopes.Transaction{t1, t2, t3}
 	for _, entry := range toWrite {
-		err = writer.Write(ctx, entry)
+		err = writer.WriteTransaction(ctx, entry)
 		if err != nil {
 			t.Error(err)
 			return

--- a/persist/filesystem/loader_v2_test.go
+++ b/persist/filesystem/loader_v2_test.go
@@ -116,14 +116,14 @@ func TestCache_Load_reuseHits(t *testing.T) {
 	}
 
 	var want envelopes.State
-	err = subject.Load(ctx, targetId, &want)
+	err = subject.LoadState(ctx, targetId, &want)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
 	var got envelopes.State
-	err = subject.Load(ctx, targetId, &got)
+	err = subject.LoadState(ctx, targetId, &got)
 	if err != nil {
 		t.Error(err)
 		return

--- a/persist/filesystem/repository_test.go
+++ b/persist/filesystem/repository_test.go
@@ -75,7 +75,7 @@ func TestCreateRepositoryLayout1(t *testing.T) {
 		},
 	}
 
-	err = repo.Write(ctx, exampleTransaction)
+	err = repo.WriteTransaction(ctx, exampleTransaction)
 	if err != nil {
 		t.Error(err)
 	}

--- a/persist/filesystem/repository_test.go
+++ b/persist/filesystem/repository_test.go
@@ -40,7 +40,7 @@ func TestOpenRepositoryLayout1(t *testing.T) {
 	}
 
 	var head envelopes.Transaction
-	err = repo.Load(ctx, headId, &head)
+	err = repo.LoadTransaction(ctx, headId, &head)
 	if err != nil {
 		t.Error(err)
 	}

--- a/persist/json/loader_v1.go
+++ b/persist/json/loader_v1.go
@@ -18,7 +18,7 @@ type LoaderV1 struct {
 }
 
 func NewLoaderV1(fetcher persist.Fetcher) (*LoaderV1, error) {
-	retval :=  &LoaderV1{
+	retval := &LoaderV1{
 		Fetcher: fetcher,
 	}
 	retval.loopback = retval
@@ -28,53 +28,25 @@ func NewLoaderV1(fetcher persist.Fetcher) (*LoaderV1, error) {
 
 func NewLoaderV1WithLoopback(fetcher persist.Fetcher, loopback persist.Loader) (*LoaderV1, error) {
 	return &LoaderV1{
-		Fetcher: fetcher,
+		Fetcher:  fetcher,
 		loopback: loopback,
 	}, nil
 }
 
-// Load fetches and parses all objects necessary to fully rehydrate `destination` from wherever it was stashed.
-//
-// See Also:
-// - WriterV1.Write
-func (dl LoaderV1) Load(ctx context.Context, id envelopes.ID, destination envelopes.IDer) error {
-	// In recursive methods, it is easy to detect that a context has been cancelled between calls to itself.
-	// Must have default clause to prevent blocking.
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		// Intentionally Left Blank
-	}
-
-	contents, err := dl.Fetch(ctx, id)
+func (dl LoaderV1) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad *envelopes.Transaction) error {
+	marshaled, err := dl.Fetch(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	switch destination.(type) {
-	case *envelopes.Transaction:
-		return dl.loadTransaction(ctx, contents, destination.(*envelopes.Transaction))
-	case *envelopes.Budget:
-		return dl.loadBudget(ctx, contents, destination.(*envelopes.Budget))
-	case *envelopes.State:
-		return dl.loadState(ctx, contents, destination.(*envelopes.State))
-	case *envelopes.Accounts:
-		return json.Unmarshal(contents, destination)
-	default:
-		return persist.NewErrUnloadableType(destination)
-	}
-}
-
-func (dl LoaderV1) loadTransaction(ctx context.Context, marshaled []byte, toLoad *envelopes.Transaction) error {
 	var unmarshaled TransactionV1
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
 
 	var state envelopes.State
-	err = dl.loopback.Load(ctx, unmarshaled.State, &state)
+	err = dl.loopback.LoadState(ctx, unmarshaled.State, &state)
 	if err != nil {
 		return err
 	}
@@ -98,20 +70,25 @@ func (dl LoaderV1) loadTransaction(ctx context.Context, marshaled []byte, toLoad
 	return nil
 }
 
-func (dl LoaderV1) loadState(ctx context.Context, marshaled []byte, toLoad *envelopes.State) error {
+func (dl LoaderV1) LoadState(ctx context.Context, id envelopes.ID, toLoad *envelopes.State) error {
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	var unmarshaled StateV1
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
 
 	var budget envelopes.Budget
-	err = dl.loopback.Load(ctx, unmarshaled.Budget, &budget)
+	err = dl.loopback.LoadBudget(ctx, unmarshaled.Budget, &budget)
 	if err != nil {
 		return err
 	}
 
-	err = dl.loopback.Load(ctx, unmarshaled.Accounts, &toLoad.Accounts)
+	err = dl.loopback.LoadAccounts(ctx, unmarshaled.Accounts, &toLoad.Accounts)
 	if err != nil {
 		return err
 	}
@@ -120,9 +97,14 @@ func (dl LoaderV1) loadState(ctx context.Context, marshaled []byte, toLoad *enve
 	return nil
 }
 
-func (dl LoaderV1) loadBudget(ctx context.Context, marshaled []byte, toLoad *envelopes.Budget) error {
+func (dl LoaderV1) LoadBudget(ctx context.Context, id envelopes.ID, toLoad *envelopes.Budget) error {
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	var unmarshaled BudgetV1
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
@@ -131,7 +113,7 @@ func (dl LoaderV1) loadBudget(ctx context.Context, marshaled []byte, toLoad *env
 	toLoad.Children = make(map[string]*envelopes.Budget, len(unmarshaled.Children))
 	for name, childID := range unmarshaled.Children {
 		var child envelopes.Budget
-		err = dl.loopback.Load(ctx, childID, &child)
+		err = dl.loopback.LoadBudget(ctx, childID, &child)
 		if err != nil {
 			return err
 		}
@@ -141,3 +123,11 @@ func (dl LoaderV1) loadBudget(ctx context.Context, marshaled []byte, toLoad *env
 	return nil
 }
 
+func (dl LoaderV1) LoadAccounts(ctx context.Context, id envelopes.ID, toLoad *envelopes.Accounts) error {
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(marshaled, toLoad)
+}

--- a/persist/json/loader_v2.go
+++ b/persist/json/loader_v2.go
@@ -33,48 +33,20 @@ type LoaderV2 struct {
 	loopback persist.Loader
 }
 
-// Load fetches and parses all objects necessary to fully rehydrate `destination` from wherever it was stashed.
-//
-// See Also:
-// - WriterV2.Write
-func (dl LoaderV2) Load(ctx context.Context, id envelopes.ID, destination envelopes.IDer) error {
-	// In recursive methods, it is easy to detect that a context has been cancelled between calls to itself.
-	// Must have default clause to prevent blocking.
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		// Intentionally Left Blank
-	}
-
-	contents, err := dl.Fetch(ctx, id)
+func (dl LoaderV2) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad *envelopes.Transaction) error {
+	marshaled, err := dl.Fetch(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	switch destination.(type) {
-	case *envelopes.Transaction:
-		return dl.loadTransaction(ctx, contents, destination.(*envelopes.Transaction))
-	case *envelopes.Budget:
-		return dl.loadBudget(ctx, contents, destination.(*envelopes.Budget))
-	case *envelopes.State:
-		return dl.loadState(ctx, contents, destination.(*envelopes.State))
-	case *envelopes.Accounts:
-		return json.Unmarshal(contents, destination)
-	default:
-		return persist.NewErrUnloadableType(destination)
-	}
-}
-
-func (dl LoaderV2) loadTransaction(ctx context.Context, marshaled []byte, toLoad *envelopes.Transaction) error {
 	var unmarshaled TransactionV2
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
 
 	var state envelopes.State
-	err = dl.loopback.Load(ctx, unmarshaled.State, &state)
+	err = dl.loopback.LoadState(ctx, unmarshaled.State, &state)
 	if err != nil {
 		return err
 	}
@@ -94,20 +66,25 @@ func (dl LoaderV2) loadTransaction(ctx context.Context, marshaled []byte, toLoad
 	return nil
 }
 
-func (dl LoaderV2) loadState(ctx context.Context, marshaled []byte, toLoad *envelopes.State) error {
+func (dl LoaderV2) LoadState(ctx context.Context, id envelopes.ID, toLoad *envelopes.State) error {
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	var unmarshaled StateV2
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
 
 	var budget envelopes.Budget
-	err = dl.loopback.Load(ctx, unmarshaled.Budget, &budget)
+	err = dl.loopback.LoadBudget(ctx, unmarshaled.Budget, &budget)
 	if err != nil {
 		return err
 	}
 
-	err = dl.loopback.Load(ctx, unmarshaled.Accounts, &toLoad.Accounts)
+	err = dl.loopback.LoadAccounts(ctx, unmarshaled.Accounts, &toLoad.Accounts)
 	if err != nil {
 		return err
 	}
@@ -116,9 +93,14 @@ func (dl LoaderV2) loadState(ctx context.Context, marshaled []byte, toLoad *enve
 	return nil
 }
 
-func (dl LoaderV2) loadBudget(ctx context.Context, marshaled []byte, toLoad *envelopes.Budget) error {
+func (dl LoaderV2) LoadBudget(ctx context.Context, id envelopes.ID, toLoad *envelopes.Budget) error {
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	var unmarshaled BudgetV2
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
@@ -127,7 +109,7 @@ func (dl LoaderV2) loadBudget(ctx context.Context, marshaled []byte, toLoad *env
 	toLoad.Children = make(map[string]*envelopes.Budget, len(unmarshaled.Children))
 	for name, childID := range unmarshaled.Children {
 		var child envelopes.Budget
-		err = dl.loopback.Load(ctx, childID, &child)
+		err = dl.loopback.LoadBudget(ctx, childID, &child)
 		if err != nil {
 			return err
 		}
@@ -135,4 +117,13 @@ func (dl LoaderV2) loadBudget(ctx context.Context, marshaled []byte, toLoad *env
 	}
 
 	return nil
+}
+
+func (dl LoaderV2) LoadAccounts(ctx context.Context, id envelopes.ID, toLoad *envelopes.Accounts) error {
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(marshaled, toLoad)
 }

--- a/persist/json/loader_v3.go
+++ b/persist/json/loader_v3.go
@@ -35,48 +35,20 @@ type LoaderV3 struct {
 	loopback persist.Loader
 }
 
-// Load fetches and parses all objects necessary to fully rehydrate `destination` from wherever it was stashed.
-//
-// See Also:
-// - WriterV3.Write
-func (dl LoaderV3) Load(ctx context.Context, id envelopes.ID, destination envelopes.IDer) error {
-	// In recursive methods, it is easy to detect that a context has been cancelled between calls to itself.
-	// Must have default clause to prevent blocking.
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		// Intentionally Left Blank
-	}
-
-	contents, err := dl.Fetch(ctx, id)
+func (dl LoaderV3) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad *envelopes.Transaction) error {
+	marshaled, err := dl.Fetch(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	switch destination.(type) {
-	case *envelopes.Transaction:
-		return dl.loadTransaction(ctx, contents, destination.(*envelopes.Transaction))
-	case *envelopes.Budget:
-		return dl.loadBudget(ctx, contents, destination.(*envelopes.Budget))
-	case *envelopes.State:
-		return dl.loadState(ctx, contents, destination.(*envelopes.State))
-	case *envelopes.Accounts:
-		return json.Unmarshal(contents, destination)
-	default:
-		return persist.NewErrUnloadableType(destination)
-	}
-}
-
-func (dl LoaderV3) loadTransaction(ctx context.Context, marshaled []byte, toLoad *envelopes.Transaction) error {
 	var unmarshaled TransactionV3
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
 
 	var state envelopes.State
-	err = dl.loopback.Load(ctx, unmarshaled.State, &state)
+	err = dl.loopback.LoadState(ctx, unmarshaled.State, &state)
 	if err != nil {
 		return err
 	}
@@ -96,20 +68,25 @@ func (dl LoaderV3) loadTransaction(ctx context.Context, marshaled []byte, toLoad
 	return nil
 }
 
-func (dl LoaderV3) loadState(ctx context.Context, marshaled []byte, toLoad *envelopes.State) error {
+func (dl LoaderV3) LoadState(ctx context.Context, id envelopes.ID, toLoad *envelopes.State) error {
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	var unmarshaled StateV3
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
 
 	var budget envelopes.Budget
-	err = dl.loopback.Load(ctx, unmarshaled.Budget, &budget)
+	err = dl.loopback.LoadBudget(ctx, unmarshaled.Budget, &budget)
 	if err != nil {
 		return err
 	}
 
-	err = dl.loopback.Load(ctx, unmarshaled.Accounts, &toLoad.Accounts)
+	err = dl.loopback.LoadAccounts(ctx, unmarshaled.Accounts, &toLoad.Accounts)
 	if err != nil {
 		return err
 	}
@@ -118,9 +95,14 @@ func (dl LoaderV3) loadState(ctx context.Context, marshaled []byte, toLoad *enve
 	return nil
 }
 
-func (dl LoaderV3) loadBudget(ctx context.Context, marshaled []byte, toLoad *envelopes.Budget) error {
+func (dl LoaderV3) LoadBudget(ctx context.Context, id envelopes.ID, toLoad *envelopes.Budget) error {
+
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
 	var unmarshaled BudgetV3
-	err := json.Unmarshal(marshaled, &unmarshaled)
+	err = json.Unmarshal(marshaled, &unmarshaled)
 	if err != nil {
 		return err
 	}
@@ -129,7 +111,7 @@ func (dl LoaderV3) loadBudget(ctx context.Context, marshaled []byte, toLoad *env
 	toLoad.Children = make(map[string]*envelopes.Budget, len(unmarshaled.Children))
 	for name, childID := range unmarshaled.Children {
 		var child envelopes.Budget
-		err = dl.loopback.Load(ctx, childID, &child)
+		err = dl.loopback.LoadBudget(ctx, childID, &child)
 		if err != nil {
 			return err
 		}
@@ -137,4 +119,13 @@ func (dl LoaderV3) loadBudget(ctx context.Context, marshaled []byte, toLoad *env
 	}
 
 	return nil
+}
+
+func (dl LoaderV3) LoadAccounts(ctx context.Context, id envelopes.ID, toLoad *envelopes.Accounts) error {
+	marshaled, err := dl.Fetch(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(marshaled, toLoad)
 }

--- a/persist/json/models_v2_test.go
+++ b/persist/json/models_v2_test.go
@@ -146,7 +146,7 @@ func Test_StateRoundtrip(t *testing.T) {
 		}
 
 		var rehydrated envelopes.State
-		err = reader.Load(ctx, want, &rehydrated)
+		err = reader.LoadState(ctx, want, &rehydrated)
 		if err != nil {
 			t.Errorf("(%s) unable to read subject: %v", name, err)
 			continue

--- a/persist/json/models_v2_test.go
+++ b/persist/json/models_v2_test.go
@@ -139,7 +139,7 @@ func Test_StateRoundtrip(t *testing.T) {
 	for name, subject := range testCases {
 		want := subject.ID()
 
-		err := saver.Write(ctx, subject)
+		err := saver.WriteState(ctx, subject)
 		if err != nil {
 			t.Errorf("(%s) unable to write subject: %v", name, err)
 			continue

--- a/persist/json/writer_v2.go
+++ b/persist/json/writer_v2.go
@@ -3,8 +3,6 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"reflect"
 
 	"github.com/marstr/envelopes"
 	"github.com/marstr/envelopes/persist"
@@ -35,40 +33,7 @@ func NewWriterV2WithLoopback(stasher persist.Stasher, loopback persist.Writer) (
 	return retval, nil
 }
 
-// Write uses the persist.Stasher it is composed of to write the given Envelopes object to a persistent storage space.
-func (dw WriterV2) Write(ctx context.Context, subject envelopes.IDer) error {
-	// In recursive methods, it is easy to detect that a context has been cancelled between calls to itself.
-	// Must have default clause to prevent blocking.
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		// Intentionally Left Blank
-	}
-
-	switch subject.(type) {
-	case envelopes.Transaction:
-		return dw.writeTransaction(ctx, subject.(envelopes.Transaction))
-	case *envelopes.Transaction:
-		return dw.writeTransaction(ctx, *subject.(*envelopes.Transaction))
-	case envelopes.State:
-		return dw.writeState(ctx, subject.(envelopes.State))
-	case *envelopes.State:
-		return dw.writeState(ctx, *subject.(*envelopes.State))
-	case envelopes.Budget:
-		return dw.writeBudget(ctx, subject.(envelopes.Budget))
-	case *envelopes.Budget:
-		return dw.writeBudget(ctx, *subject.(*envelopes.Budget))
-	case envelopes.Accounts:
-		return dw.writeAccounts(ctx, subject.(envelopes.Accounts))
-	case *envelopes.Accounts:
-		return dw.writeAccounts(ctx, *subject.(*envelopes.Accounts))
-	default:
-		return fmt.Errorf("unknown type: %s", reflect.TypeOf(subject).Name())
-	}
-}
-
-func (dw WriterV2) writeTransaction(ctx context.Context, subject envelopes.Transaction) error {
+func (dw WriterV2) WriteTransaction(ctx context.Context, subject envelopes.Transaction) error {
 	if subject.State == nil {
 		subject.State = &envelopes.State{}
 	}
@@ -86,7 +51,7 @@ func (dw WriterV2) writeTransaction(ctx context.Context, subject envelopes.Trans
 	toMarshal.Committer.Email = subject.Committer.Email
 	toMarshal.RecordId = BankRecordIDV2(subject.RecordID)
 
-	err := dw.loopback.Write(ctx, subject.State)
+	err := dw.loopback.WriteState(ctx, *subject.State)
 	if err != nil {
 		return err
 	}
@@ -99,11 +64,11 @@ func (dw WriterV2) writeTransaction(ctx context.Context, subject envelopes.Trans
 	return dw.Stash(ctx, subject.ID(), marshaled)
 }
 
-func (dw WriterV2) writeState(ctx context.Context, subject envelopes.State) error {
+func (dw WriterV2) WriteState(ctx context.Context, subject envelopes.State) error {
 	if subject.Accounts == nil {
 		subject.Accounts = make(envelopes.Accounts, 0)
 	}
-	err := dw.loopback.Write(ctx, subject.Accounts)
+	err := dw.loopback.WriteAccounts(ctx, subject.Accounts)
 	if err != nil {
 		return err
 	}
@@ -111,7 +76,7 @@ func (dw WriterV2) writeState(ctx context.Context, subject envelopes.State) erro
 	if subject.Budget == nil {
 		subject.Budget = &envelopes.Budget{}
 	}
-	err = dw.loopback.Write(ctx, subject.Budget)
+	err = dw.loopback.WriteBudget(ctx, *subject.Budget)
 	if err != nil {
 		return err
 	}
@@ -128,12 +93,12 @@ func (dw WriterV2) writeState(ctx context.Context, subject envelopes.State) erro
 	return dw.Stash(ctx, subject.ID(), marshaled)
 }
 
-func (dw WriterV2) writeBudget(ctx context.Context, subject envelopes.Budget) error {
+func (dw WriterV2) WriteBudget(ctx context.Context, subject envelopes.Budget) error {
 	if subject.Children == nil {
 		subject.Children = make(map[string]*envelopes.Budget, 0)
 	}
 	for _, child := range subject.Children {
-		err := dw.loopback.Write(ctx, child)
+		err := dw.loopback.WriteBudget(ctx, *child)
 		if err != nil {
 			return err
 		}
@@ -154,7 +119,7 @@ func (dw WriterV2) writeBudget(ctx context.Context, subject envelopes.Budget) er
 	return dw.Stash(ctx, subject.ID(), marshaled)
 }
 
-func (dw WriterV2) writeAccounts(ctx context.Context, subject envelopes.Accounts) error {
+func (dw WriterV2) WriteAccounts(ctx context.Context, subject envelopes.Accounts) error {
 	marshaled, err := json.Marshal(subject)
 	if err != nil {
 		return err

--- a/persist/json/writer_v2_test.go
+++ b/persist/json/writer_v2_test.go
@@ -20,7 +20,7 @@ func TestWriterV2_writeAccounts(t *testing.T) {
 
 	mockStore := make(mockDisk)
 	subject := WriterV2{Stasher: mockStore}
-	err := subject.Write(ctx, exampleAccounts)
+	err := subject.WriteAccounts(ctx, exampleAccounts)
 	if err != nil {
 		t.Error(err)
 	}

--- a/persist/json/writer_v3_test.go
+++ b/persist/json/writer_v3_test.go
@@ -20,7 +20,7 @@ func TestWriterV3_writeAccounts(t *testing.T) {
 
 	mockStore := make(mockDisk)
 	subject := WriterV3{Stasher: mockStore}
-	err := subject.Write(ctx, exampleAccounts)
+	err := subject.WriteAccounts(ctx, exampleAccounts)
 	if err != nil {
 		t.Error(err)
 	}

--- a/persist/loader_test.go
+++ b/persist/loader_test.go
@@ -34,42 +34,42 @@ func TestNearestCommonAncestor_noCommonAncestor(t *testing.T) {
 	gen3bid := gen3b.ID()
 
 	repo := NewMockRepository(0, 8)
-	err = repo.Write(ctx, gen1a)
+	err = repo.WriteTransaction(ctx, gen1a)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen1b)
+	err = repo.WriteTransaction(ctx, gen1b)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2aa)
+	err = repo.WriteTransaction(ctx, gen2aa)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2ab)
+	err = repo.WriteTransaction(ctx, gen2ab)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2ba)
+	err = repo.WriteTransaction(ctx, gen2ba)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2bb)
+	err = repo.WriteTransaction(ctx, gen2bb)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen3a)
+	err = repo.WriteTransaction(ctx, gen3a)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen3b)
+	err = repo.WriteTransaction(ctx, gen3b)
 	if err != nil {
 		t.Error(err)
 		return
@@ -147,19 +147,19 @@ func TestNearestCommonAncestor_sharedParent(t *testing.T) {
 	gen1bid := gen1b.ID()
 
 	repo := NewMockRepository(0, 4)
-	err = repo.Write(ctx, root)
+	err = repo.WriteTransaction(ctx, root)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen1a)
+	err = repo.WriteTransaction(ctx, gen1a)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen1b)
+	err = repo.WriteTransaction(ctx, gen1b)
 	if err != nil {
 		t.Error(err)
 		return
@@ -186,13 +186,13 @@ func TestNearestCommonAncestor_parentAndChild(t *testing.T) {
 	cid := child.ID()
 
 	repo := NewMockRepository(0, 2)
-	err = repo.Write(ctx, parent)
+	err = repo.WriteTransaction(ctx, parent)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, child)
+	err = repo.WriteTransaction(ctx, child)
 	if err != nil {
 		t.Error(err)
 		return
@@ -234,58 +234,56 @@ func TestNearestCommonAncestor_multipleYs(t *testing.T) {
 	gen3b := envelopes.Transaction{Comment: "Gen3 - B", Parents: []envelopes.ID{gen2baid, gen2bbid}}
 	gen3bid := gen3b.ID()
 
-
 	repo := NewMockRepository(0, 9)
-	err = repo.Write(ctx, root)
+	err = repo.WriteTransaction(ctx, root)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen1a)
+	err = repo.WriteTransaction(ctx, gen1a)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen1b)
+	err = repo.WriteTransaction(ctx, gen1b)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen2aa)
+	err = repo.WriteTransaction(ctx, gen2aa)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen2ab)
+	err = repo.WriteTransaction(ctx, gen2ab)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen2ba)
+	err = repo.WriteTransaction(ctx, gen2ba)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen2bb)
+	err = repo.WriteTransaction(ctx, gen2bb)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	err = repo.Write(ctx, gen3a)
+	err = repo.WriteTransaction(ctx, gen3a)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-
-	err = repo.Write(ctx, gen3b)
+	err = repo.WriteTransaction(ctx, gen3b)
 	if err != nil {
 		t.Error(err)
 		return
@@ -311,12 +309,12 @@ func TestLoadImpact_simple(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(10,1),
+					"USD": big.NewRat(10, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(10,1),
+					"USD": big.NewRat(10, 1),
 				},
 			},
 		},
@@ -328,12 +326,12 @@ func TestLoadImpact_simple(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(15,1),
+					"USD": big.NewRat(15, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(15,1),
+					"USD": big.NewRat(15, 1),
 				},
 			},
 		},
@@ -341,12 +339,12 @@ func TestLoadImpact_simple(t *testing.T) {
 	}
 
 	repo := NewMockRepository(0, 2)
-	err = repo.Write(ctx, parent)
+	err = repo.WriteTransaction(ctx, parent)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, child)
+	err = repo.WriteTransaction(ctx, child)
 	if err != nil {
 		t.Error(err)
 		return
@@ -362,12 +360,12 @@ func TestLoadImpact_simple(t *testing.T) {
 	want := envelopes.Impact{
 		Budget: &envelopes.Budget{
 			Balance: envelopes.Balance{
-				"USD":big.NewRat(5,1),
+				"USD": big.NewRat(5, 1),
 			},
 		},
 		Accounts: map[string]envelopes.Balance{
-			"checking":{
-				"USD": big.NewRat(5,1),
+			"checking": {
+				"USD": big.NewRat(5, 1),
 			},
 		},
 	}
@@ -385,15 +383,15 @@ func TestLoadImpact_noImpactMerge(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(30,1),
+					"USD": big.NewRat(30, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(10,1),
+					"USD": big.NewRat(10, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(20, 1),
+					"USD": big.NewRat(20, 1),
 				},
 			},
 		},
@@ -405,15 +403,15 @@ func TestLoadImpact_noImpactMerge(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(35,1),
+					"USD": big.NewRat(35, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(15,1),
+					"USD": big.NewRat(15, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(20,1),
+					"USD": big.NewRat(20, 1),
 				},
 			},
 		},
@@ -425,15 +423,15 @@ func TestLoadImpact_noImpactMerge(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(35,1),
+					"USD": big.NewRat(35, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(10,1),
+					"USD": big.NewRat(10, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(25,1),
+					"USD": big.NewRat(25, 1),
 				},
 			},
 		},
@@ -445,15 +443,15 @@ func TestLoadImpact_noImpactMerge(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(40,1),
+					"USD": big.NewRat(40, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(15,1),
+					"USD": big.NewRat(15, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(25,1),
+					"USD": big.NewRat(25, 1),
 				},
 			},
 		},
@@ -461,22 +459,22 @@ func TestLoadImpact_noImpactMerge(t *testing.T) {
 	}
 
 	repo := NewMockRepository(0, 4)
-	err = repo.Write(ctx, gen1)
+	err = repo.WriteTransaction(ctx, gen1)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2a)
+	err = repo.WriteTransaction(ctx, gen2a)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2b)
+	err = repo.WriteTransaction(ctx, gen2b)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen3)
+	err = repo.WriteTransaction(ctx, gen3)
 	if err != nil {
 		t.Error(err)
 		return
@@ -504,15 +502,15 @@ func TestLoadImpact_duplicateReconciled(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(30,1),
+					"USD": big.NewRat(30, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(10,1),
+					"USD": big.NewRat(10, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(20, 1),
+					"USD": big.NewRat(20, 1),
 				},
 			},
 		},
@@ -524,15 +522,15 @@ func TestLoadImpact_duplicateReconciled(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(35,1),
+					"USD": big.NewRat(35, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(15,1),
+					"USD": big.NewRat(15, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(20,1),
+					"USD": big.NewRat(20, 1),
 				},
 			},
 		},
@@ -544,15 +542,15 @@ func TestLoadImpact_duplicateReconciled(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(35,1),
+					"USD": big.NewRat(35, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(15,1),
+					"USD": big.NewRat(15, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(20,1),
+					"USD": big.NewRat(20, 1),
 				},
 			},
 		},
@@ -564,15 +562,15 @@ func TestLoadImpact_duplicateReconciled(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(35,1),
+					"USD": big.NewRat(35, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(15,1),
+					"USD": big.NewRat(15, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(20,1),
+					"USD": big.NewRat(20, 1),
 				},
 			},
 		},
@@ -580,22 +578,22 @@ func TestLoadImpact_duplicateReconciled(t *testing.T) {
 	}
 
 	repo := NewMockRepository(0, 4)
-	err = repo.Write(ctx, gen1)
+	err = repo.WriteTransaction(ctx, gen1)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2a)
+	err = repo.WriteTransaction(ctx, gen2a)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2b)
+	err = repo.WriteTransaction(ctx, gen2b)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen3)
+	err = repo.WriteTransaction(ctx, gen3)
 	if err != nil {
 		t.Error(err)
 		return
@@ -611,12 +609,12 @@ func TestLoadImpact_duplicateReconciled(t *testing.T) {
 	want := envelopes.Impact{
 		Budget: &envelopes.Budget{
 			Balance: envelopes.Balance{
-				"USD": big.NewRat(-5,1),
+				"USD": big.NewRat(-5, 1),
 			},
 		},
 		Accounts: map[string]envelopes.Balance{
 			"checking": {
-				"USD":big.NewRat(-5,1),
+				"USD": big.NewRat(-5, 1),
 			},
 		},
 	}
@@ -635,15 +633,15 @@ func TestLoadImpact_noCommonAncestor(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(35,1),
+					"USD": big.NewRat(35, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(10,1),
+					"USD": big.NewRat(10, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(25,1),
+					"USD": big.NewRat(25, 1),
 				},
 			},
 		},
@@ -654,15 +652,15 @@ func TestLoadImpact_noCommonAncestor(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(35,1),
+					"USD": big.NewRat(35, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(15,1),
+					"USD": big.NewRat(15, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(20,1),
+					"USD": big.NewRat(20, 1),
 				},
 			},
 		},
@@ -673,15 +671,15 @@ func TestLoadImpact_noCommonAncestor(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(70,1),
+					"USD": big.NewRat(70, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(25,1),
+					"USD": big.NewRat(25, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(45,1),
+					"USD": big.NewRat(45, 1),
 				},
 			},
 		},
@@ -689,17 +687,17 @@ func TestLoadImpact_noCommonAncestor(t *testing.T) {
 	}
 
 	repo := NewMockRepository(0, 3)
-	err = repo.Write(ctx, gen1a)
+	err = repo.WriteTransaction(ctx, gen1a)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen1b)
+	err = repo.WriteTransaction(ctx, gen1b)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	err = repo.Write(ctx, gen2)
+	err = repo.WriteTransaction(ctx, gen2)
 	if err != nil {
 		t.Error(err)
 		return
@@ -728,22 +726,22 @@ func TestLoadImpact_island(t *testing.T) {
 		State: &envelopes.State{
 			Budget: &envelopes.Budget{
 				Balance: envelopes.Balance{
-					"USD": big.NewRat(35,1),
+					"USD": big.NewRat(35, 1),
 				},
 			},
 			Accounts: map[string]envelopes.Balance{
 				"checking": {
-					"USD":big.NewRat(10,1),
+					"USD": big.NewRat(10, 1),
 				},
 				"savings": {
-					"USD":big.NewRat(25,1),
+					"USD": big.NewRat(25, 1),
 				},
 			},
 		},
 	}
 
 	repo := NewMockRepository(0, 1)
-	err = repo.Write(ctx, gen1)
+	err = repo.WriteTransaction(ctx, gen1)
 	if err != nil {
 		t.Error(err)
 		return
@@ -764,10 +762,10 @@ func TestLoadImpact_island(t *testing.T) {
 		},
 		Accounts: map[string]envelopes.Balance{
 			"checking": {
-				"USD":big.NewRat(10,1),
+				"USD": big.NewRat(10, 1),
 			},
-			"savings":{
-				"USD":big.NewRat(25,1),
+			"savings": {
+				"USD": big.NewRat(25, 1),
 			},
 		},
 	}

--- a/persist/refspec.go
+++ b/persist/refspec.go
@@ -161,7 +161,7 @@ func resolveTransactionRefSpec(ctx context.Context, loader Loader, subject RefSp
 	}
 
 	var target envelopes.Transaction
-	err = loader.Load(ctx, result, &target)
+	err = loader.LoadTransaction(ctx, result, &target)
 	if err != nil {
 		return envelopes.ID{}, err
 	}

--- a/persist/refspec_test.go
+++ b/persist/refspec_test.go
@@ -37,7 +37,7 @@ func Test_Resolve(t *testing.T) {
 		Comment: "A!",
 	}
 	aid := transactions[0].ID()
-	err := mockRepo.Write(ctx, transactions[0])
+	err := mockRepo.WriteTransaction(ctx, transactions[0])
 	if err != nil {
 		t.Error(err)
 		return
@@ -50,7 +50,7 @@ func Test_Resolve(t *testing.T) {
 		},
 	}
 	bid := transactions[1].ID()
-	err = mockRepo.Write(ctx, transactions[1])
+	err = mockRepo.WriteTransaction(ctx, transactions[1])
 	if err != nil {
 		t.Error(err)
 		return
@@ -68,7 +68,7 @@ func Test_Resolve(t *testing.T) {
 		},
 	}
 	cid := transactions[2].ID()
-	err = mockRepo.Write(ctx, transactions[2])
+	err = mockRepo.WriteTransaction(ctx, transactions[2])
 	if err != nil {
 		t.Error(err)
 		return
@@ -81,7 +81,7 @@ func Test_Resolve(t *testing.T) {
 		},
 	}
 	did := transactions[3].ID()
-	err = mockRepo.Write(ctx, transactions[3])
+	err = mockRepo.WriteTransaction(ctx, transactions[3])
 	if err != nil {
 		t.Error(err)
 		return

--- a/persist/repository.go
+++ b/persist/repository.go
@@ -94,7 +94,7 @@ func bareClone(ctx context.Context, src BareRepositoryReader, dest BareRepositor
 		return err
 	}
 
-	heads := make([]envelopes.ID,0)
+	heads := make([]envelopes.ID, 0)
 
 	for branch := range rawBranches {
 		val, err := src.ReadBranch(ctx, branch)
@@ -109,11 +109,11 @@ func bareClone(ctx context.Context, src BareRepositoryReader, dest BareRepositor
 	}
 
 	walker := Walker{
-		Loader: src,
+		Loader:   src,
 		MaxDepth: options.Depth,
 	}
 
 	return walker.Walk(ctx, func(ctx context.Context, _ envelopes.ID, transaction envelopes.Transaction) error {
-		return dest.Write(ctx, transaction)
+		return dest.WriteTransaction(ctx, transaction)
 	}, heads...)
 }

--- a/persist/repository_test.go
+++ b/persist/repository_test.go
@@ -2,13 +2,14 @@ package persist
 
 import (
 	"context"
-	"github.com/marstr/envelopes"
 	"testing"
 	"time"
+
+	"github.com/marstr/envelopes"
 )
 
 func TestBareClone(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 90 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	t.Run("linear", testBareCloneLinear(ctx))
@@ -24,24 +25,24 @@ func testBareCloneLinear(ctx context.Context) func(*testing.T) {
 		expected := make(map[envelopes.ID]envelopes.Transaction)
 
 		a := envelopes.Transaction{Comment: "Deepest"}
-		if err := src.Write(ctx, a); err != nil {
+		if err := src.WriteTransaction(ctx, a); err != nil {
 			t.Error(err)
 		}
 
 		b := envelopes.Transaction{Comment: "Deeper", Parents: []envelopes.ID{a.ID()}}
-		if err := src.Write(ctx, b); err != nil {
+		if err := src.WriteTransaction(ctx, b); err != nil {
 			t.Error(err)
 		}
 		expected[b.Parents[0]] = a
 
 		c := envelopes.Transaction{Comment: "Deep", Parents: []envelopes.ID{b.ID()}}
-		if err := src.Write(ctx, c); err != nil {
+		if err := src.WriteTransaction(ctx, c); err != nil {
 			t.Error(err)
 		}
 		expected[c.Parents[0]] = b
 
 		d := envelopes.Transaction{Comment: "Shallow", Parents: []envelopes.ID{c.ID()}}
-		if err := src.Write(ctx, d); err != nil {
+		if err := src.WriteTransaction(ctx, d); err != nil {
 			t.Error(err)
 		}
 		expected[d.Parents[0]] = c
@@ -77,25 +78,25 @@ func testBareCloneDiamond(ctx context.Context) func(*testing.T) {
 		src := NewMockRepository(branchCount, transactionCount)
 
 		a := envelopes.Transaction{Comment: "Deepest"}
-		if err := src.Write(ctx, a); err != nil {
+		if err := src.WriteTransaction(ctx, a); err != nil {
 			t.Error(err)
 		}
 		aId := a.ID()
 
 		b := envelopes.Transaction{Comment: "Deeper", Parents: []envelopes.ID{aId}}
-		if err := src.Write(ctx, b); err != nil {
+		if err := src.WriteTransaction(ctx, b); err != nil {
 			t.Error(err)
 		}
 		bId := b.ID()
 
 		c := envelopes.Transaction{Comment: "Deep", Parents: []envelopes.ID{aId}}
-		if err := src.Write(ctx, c); err != nil {
+		if err := src.WriteTransaction(ctx, c); err != nil {
 			t.Error(err)
 		}
 		cId := c.ID()
 
 		d := envelopes.Transaction{Comment: "Shallow", Parents: []envelopes.ID{cId, bId}}
-		if err := src.Write(ctx, d); err != nil {
+		if err := src.WriteTransaction(ctx, d); err != nil {
 			t.Error(err)
 		}
 		dId := d.ID()
@@ -129,19 +130,19 @@ func testBareCloneFork(ctx context.Context) func(*testing.T) {
 		src := NewMockRepository(branchCount, transactionCount)
 
 		b := envelopes.Transaction{Comment: "Deeper", Parents: []envelopes.ID{}}
-		if err := src.Write(ctx, b); err != nil {
+		if err := src.WriteTransaction(ctx, b); err != nil {
 			t.Error(err)
 		}
 		bId := b.ID()
 
 		c := envelopes.Transaction{Comment: "Deep", Parents: []envelopes.ID{}}
-		if err := src.Write(ctx, c); err != nil {
+		if err := src.WriteTransaction(ctx, c); err != nil {
 			t.Error(err)
 		}
 		cId := c.ID()
 
 		d := envelopes.Transaction{Comment: "Shallow", Parents: []envelopes.ID{cId, bId}}
-		if err := src.Write(ctx, d); err != nil {
+		if err := src.WriteTransaction(ctx, d); err != nil {
 			t.Error(err)
 		}
 		dId := d.ID()

--- a/persist/repository_test.go
+++ b/persist/repository_test.go
@@ -209,7 +209,7 @@ func bareRepositoriesEqual(ctx context.Context, left, right BareRepositoryReader
 	walker := Walker{Loader: left}
 	var current envelopes.Transaction
 	err = walker.Walk(ctx, func(ctx context.Context, id envelopes.ID, transaction envelopes.Transaction) error {
-		err = right.Load(ctx, id, &current)
+		err = right.LoadTransaction(ctx, id, &current)
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func bareRepositoriesEqual(ctx context.Context, left, right BareRepositoryReader
 	// Walk through all transactions in the right repository, and make sure they're all present in the left repository.
 	walker.Loader = right
 	err = walker.Walk(ctx, func(ctx context.Context, id envelopes.ID, transaction envelopes.Transaction) error {
-		err = left.Load(ctx, id, &current)
+		err = left.LoadTransaction(ctx, id, &current)
 		if err != nil {
 			return err
 		}

--- a/persist/walker.go
+++ b/persist/walker.go
@@ -4,6 +4,7 @@ package persist
 
 import (
 	"context"
+
 	"github.com/marstr/collection/v2"
 	"github.com/marstr/envelopes"
 )
@@ -60,7 +61,7 @@ func (w *Walker) Walk(ctx context.Context, action WalkFunc, heads ...envelopes.I
 		}
 
 		var current envelopes.Transaction
-		err := w.Loader.Load(ctx, currentEntry.ID, &current)
+		err := w.Loader.LoadTransaction(ctx, currentEntry.ID, &current)
 		if err != nil {
 			return err
 		}

--- a/persist/walker_test.go
+++ b/persist/walker_test.go
@@ -279,7 +279,7 @@ func respectDepth(ctx context.Context) func(*testing.T) {
 
 		for k, _ := range expected {
 			var missed envelopes.Transaction
-			if err := repo.Load(ctx, k, &missed); err != nil {
+			if err := repo.LoadTransaction(ctx, k, &missed); err != nil {
 				t.Errorf("missed expected transaction:\n\tID:   %s\n\tDesc: failed to load", k)
 				continue
 			}

--- a/persist/walker_test.go
+++ b/persist/walker_test.go
@@ -2,8 +2,9 @@ package persist
 
 import (
 	"context"
-	"github.com/marstr/envelopes"
 	"testing"
+
+	"github.com/marstr/envelopes"
 )
 
 func TestWalker_Walk(t *testing.T) {
@@ -20,7 +21,7 @@ func chain(ctx context.Context) func(t *testing.T) {
 		Comment: "First!",
 	}
 	aid := a.ID()
-	err := cache.Write(ctx, a)
+	err := cache.WriteTransaction(ctx, a)
 	if err != nil {
 		panic(err)
 	}
@@ -32,7 +33,7 @@ func chain(ctx context.Context) func(t *testing.T) {
 		},
 	}
 	bid := b.ID()
-	err = cache.Write(ctx, b)
+	err = cache.WriteTransaction(ctx, b)
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +74,7 @@ func fork(ctx context.Context) func(t *testing.T) {
 		Comment: "First!",
 	}
 	aid := a.ID()
-	err := cache.Write(ctx, a)
+	err := cache.WriteTransaction(ctx, a)
 	if err != nil {
 		panic(err)
 	}
@@ -85,7 +86,7 @@ func fork(ctx context.Context) func(t *testing.T) {
 		},
 	}
 	bid := b.ID()
-	err = cache.Write(ctx, b)
+	err = cache.WriteTransaction(ctx, b)
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +98,7 @@ func fork(ctx context.Context) func(t *testing.T) {
 		},
 	}
 	cid := c.ID() // Eastern Iowa Airport shout-out
-	err = cache.Write(ctx, c)
+	err = cache.WriteTransaction(ctx, c)
 	if err != nil {
 		panic(err)
 	}
@@ -142,7 +143,7 @@ func respectSkipAncestors(ctx context.Context) func(t *testing.T) {
 		Comment: "First!",
 	}
 	aid := a.ID()
-	err := cache.Write(ctx, a)
+	err := cache.WriteTransaction(ctx, a)
 	if err != nil {
 		panic(err)
 	}
@@ -154,7 +155,7 @@ func respectSkipAncestors(ctx context.Context) func(t *testing.T) {
 		},
 	}
 	bid := b.ID()
-	err = cache.Write(ctx, b)
+	err = cache.WriteTransaction(ctx, b)
 	if err != nil {
 		panic(err)
 	}
@@ -166,7 +167,7 @@ func respectSkipAncestors(ctx context.Context) func(t *testing.T) {
 		},
 	}
 	cid := c.ID() // Eastern Iowa Airport shout-out
-	err = cache.Write(ctx, c)
+	err = cache.WriteTransaction(ctx, c)
 	if err != nil {
 		panic(err)
 	}
@@ -178,7 +179,7 @@ func respectSkipAncestors(ctx context.Context) func(t *testing.T) {
 		},
 	}
 	did := d.ID()
-	err = cache.Write(ctx, d)
+	err = cache.WriteTransaction(ctx, d)
 	if err != nil {
 		panic(err)
 	}
@@ -229,28 +230,28 @@ func respectDepth(ctx context.Context) func(*testing.T) {
 
 		gen1 := envelopes.Transaction{Comment: "Gen 1"}
 		gen1id := gen1.ID()
-		if err := repo.Write(ctx, gen1); err != nil {
+		if err := repo.WriteTransaction(ctx, gen1); err != nil {
 			t.Error(err)
 			return
 		}
 
 		gen2a := envelopes.Transaction{Comment: "Gen 2a", Parents: []envelopes.ID{gen1id}}
 		gen2aid := gen2a.ID()
-		if err := repo.Write(ctx, gen2a); err != nil {
+		if err := repo.WriteTransaction(ctx, gen2a); err != nil {
 			t.Error(err)
 			return
 		}
 
 		gen2b := envelopes.Transaction{Comment: "Gen 2b", Parents: []envelopes.ID{gen1id}}
 		gen2bid := gen2b.ID()
-		if err := repo.Write(ctx, gen2b); err != nil {
+		if err := repo.WriteTransaction(ctx, gen2b); err != nil {
 			t.Error(err)
 			return
 		}
 
 		gen3 := envelopes.Transaction{Comment: "Gen 3", Parents: []envelopes.ID{gen2aid, gen2bid}}
 		gen3id := gen3.ID()
-		if err := repo.Write(ctx, gen3); err != nil {
+		if err := repo.WriteTransaction(ctx, gen3); err != nil {
 			t.Error(err)
 			return
 		}
@@ -259,7 +260,6 @@ func respectDepth(ctx context.Context) func(*testing.T) {
 		expected[gen2aid] = struct{}{}
 		expected[gen2bid] = struct{}{}
 		expected[gen3id] = struct{}{}
-
 
 		subject := Walker{Loader: repo, MaxDepth: 1}
 

--- a/persist/writer.go
+++ b/persist/writer.go
@@ -16,12 +16,22 @@ package persist
 
 import (
 	"context"
+
 	"github.com/marstr/envelopes"
 )
 
 // Writer defines a contract that allows an object to express that it knows how to persist
 // an object so that it can be recalled using an instance of an object that satisfies `persist.Fetch`.
 type Writer interface {
-	// Write persists an object in durable storage where it can be retrieved later.
-	Write(ctx context.Context, subject envelopes.IDer) error
+	// WriteTransaction persists a Transaction, and all objects composing it, in durable storage where it can be retrieved later.
+	WriteTransaction(ctx context.Context, subject envelopes.Transaction) error
+
+	// WriteState persists a State, and all objects composing it, in durable storage where it can be retrieved later.
+	WriteState(ctx context.Context, subject envelopes.State) error
+
+	// WriteBudget persists a Budget, and all objects composing it, in durable storage where it can be retrieved later.
+	WriteBudget(ctx context.Context, subject envelopes.Budget) error
+
+	// WriteAccounts persist an instance of Accounts in durable storage where it can be retrieved later.
+	WriteAccounts(ctx context.Context, subject envelopes.Accounts) error
 }


### PR DESCRIPTION
Fixes #56

This overhauls the `persist.Loader` and `persist.Writer` interfaces and all implementations to have separate func definitions for each type that they should be able to handle, instead of enforcing type writing/loading capabilities at runtime.

I think previous me thought it would be convenient to not have to type out all the extra characters whenever I needed to load something. But in practice the type protection is helpful, and few if any applications will actually call anything except LoadTransaction anyway (if that), so it's not really important.