### PR TITLE
Add CalculateAmount utility

### DIFF
--- a/state.go
+++ b/state.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
+	"math/big"
+	"os"
 )
 
 type (
@@ -209,4 +211,145 @@ func (s State) subtractBudget(other State) *Budget {
 
 	// Changes have been made to this budget. Call helper to get the differences figured out.
 	return helper(s.Budget, other.Budget)
+}
+
+func CaluclateAmount(original, updated State) Balance {
+	if changed := findAccountAmount(original, updated); !changed.Equal(Balance{}) {
+		return changed
+	}
+
+	return findBudgetAmount(original, updated)
+}
+
+func findAccountAmount(original, updated State) Balance {
+	zero := big.NewRat(0, 1)
+
+	modifiedAccounts := make(Accounts, len(original.Accounts))
+
+	addedAccountNames := make(map[string]struct{}, len(original.Accounts))
+	for name := range updated.Accounts {
+		addedAccountNames[name] = struct{}{}
+	}
+
+	for name, oldBalance := range original.Accounts {
+		delete(addedAccountNames, name)
+
+		if newBalance, ok := updated.Accounts[name]; ok && newBalance.Equal(oldBalance) {
+			// Nothing has changed
+			continue
+		} else if !ok {
+			// An account was removed
+			modifiedAccounts[name] = oldBalance.Negate()
+		} else {
+			// An account had its balance modified
+			modifiedAccounts[name] = newBalance.Sub(oldBalance)
+		}
+	}
+
+	// Iterate over the accounts that weren't seen in the original, and mark them as new.
+	for name := range addedAccountNames {
+		modifiedAccounts[name] = updated.Accounts[name]
+	}
+
+	// If there was a transfer between two accounts, we don't want to mark it as amount USD 0.00, but rather that magnitude
+	// of the transfer. For that reason, we'll figure out the total negative and positive change of the accounts
+	// involved.
+	//
+	// If it was a transfer between budgets, we'll count the total deposited into the receiving accounts.
+	// If it was a deposit or credit, the amount positive or negative will get reflected because the opposite will
+	// register as a zero.
+	positiveAccountDifferences := make(Balance)
+	negativeAccountDifferences := make(Balance)
+	for _, bal := range modifiedAccounts {
+		for asset, magnitude := range bal {
+			if magnitude.Cmp(zero) > 0 {
+				incrementAsset(positiveAccountDifferences, asset, magnitude)
+			} else {
+				incrementAsset(negativeAccountDifferences, asset, magnitude)
+			}
+		}
+	}
+
+	return combineSeparated(negativeAccountDifferences, positiveAccountDifferences)
+}
+
+func findBudgetAmount(original, updated State) Balance {
+	zero := big.NewRat(0, 1)
+	// Normalize the budgets into a flattened shape for easier comparison, more like Accounts
+	const separator = string(os.PathSeparator)
+	originalBudgets := make(map[string]Balance)
+	updatedBudgets := make(map[string]Balance)
+
+	var treeFlattener func(map[string]Balance, string, *Budget)
+	treeFlattener = func(discovered map[string]Balance, currentPath string, target *Budget) {
+		discovered[currentPath] = target.Balance
+
+		for name, subTarget := range target.Children {
+			treeFlattener(discovered, currentPath+separator+name, subTarget)
+		}
+	}
+
+	treeFlattener(originalBudgets, separator, original.Budget)
+	treeFlattener(updatedBudgets, separator, updated.Budget)
+
+	// Make a list of all budget names in the updated state, so that we can find the ones which were added.
+	addedBudgets := make(map[string]struct{}, len(updatedBudgets))
+	for name := range updatedBudgets {
+		addedBudgets[name] = struct{}{}
+	}
+
+	modifiedBudgets := make(map[string]Balance, len(originalBudgets))
+
+	for name, oldBalance := range originalBudgets {
+		delete(addedBudgets, name)
+
+		if newBalance, ok := updatedBudgets[name]; ok && newBalance.Equal(oldBalance) {
+			// Nothing has changed here
+			continue
+		} else if !ok {
+			modifiedBudgets[name] = oldBalance.Negate()
+		} else {
+			modifiedBudgets[name] = newBalance.Sub(oldBalance)
+		}
+	}
+
+	for name := range addedBudgets {
+		modifiedBudgets[name] = updatedBudgets[name]
+	}
+
+	positiveBudgetDifferences := make(Balance)
+	negativeBudgetDifferences := make(Balance)
+	for _, bal := range modifiedBudgets {
+		for asset, magnitude := range bal {
+			if magnitude.Cmp(zero) > 0 {
+				incrementAsset(positiveBudgetDifferences, asset, magnitude)
+			} else {
+				incrementAsset(negativeBudgetDifferences, asset, magnitude)
+			}
+		}
+	}
+
+	return combineSeparated(negativeBudgetDifferences, positiveBudgetDifferences)
+}
+
+func combineSeparated(negative, positive Balance) Balance {
+	result := Balance{}
+
+	for k, v := range negative {
+		result[k] = v
+	}
+
+	for k, v := range positive {
+		result[k] = v
+	}
+
+	return result
+}
+
+func incrementAsset(target Balance, asset AssetType, magnitude *big.Rat) {
+	if prev, ok := target[asset]; ok {
+		prev.Add(prev, magnitude)
+	} else {
+		target[asset] = magnitude
+	}
 }


### PR DESCRIPTION
Over in [marstr/baronial](https://github.com/marstr/baronial), lots of utilities were added in the name of expedience that should have probably always put here so that other tools can also reference them. This simple function that suggests a display amount for a transaction is one of them. I'm adding it to states so that it can be used in other future apps and drive consistency across the ecosystem.