### PR TITLE
Adding Reverts field to Transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -34,6 +34,7 @@ type Transaction struct {
 	Comment     string
 	RecordID    BankRecordID
 	Parents     []ID
+	Reverts     ID
 }
 
 // ID fetches a SHA1 hash of this object that will uniquely identify it.
@@ -93,6 +94,10 @@ func (t Transaction) Equal(other Transaction) bool {
 	}
 
 	if t.RecordID != other.RecordID {
+		return false
+	}
+
+	if !t.Reverts.Equal(other.Reverts) {
 		return false
 	}
 
@@ -168,6 +173,12 @@ func (t Transaction) MarshalText() ([]byte, error) {
 	}
 	if t.RecordID != "" {
 		_, err = fmt.Fprintf(identityBuilder, "record %s\n", t.RecordID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !t.Reverts.Equal(ID{}) {
+		_, err = fmt.Fprintf(identityBuilder, "reverts %s\n", t.Reverts.String())
 		if err != nil {
 			return nil, err
 		}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -115,6 +115,36 @@ func getTestTransactionIDLock(ctx context.Context) func(*testing.T) {
 				},
 				Expected: "ebad5097e0013577f9926fa2f5f5bec385608794",
 			},
+			{
+				Subject: envelopes.Transaction{
+					Amount:     envelopes.Balance{"USD": big.NewRat(9807, 100)},
+					Merchant:   "Target",
+					PostedTime: authorTime,
+					Comment:    "Shoes",
+					Parents: []envelopes.ID{
+						envelopes.Transaction{}.ID(),
+					},
+					RecordID: "20201212 575073 2,000 202,012,128,756",
+					Reverts:  envelopes.Transaction{Comment: "Clearly erroneous"}.ID(),
+					State: &envelopes.State{
+						Budget: &envelopes.Budget{
+							Balance: envelopes.Balance{"USD": big.NewRat(4511, 100)},
+							Children: map[string]*envelopes.Budget{
+								"grocery": {
+									Balance: envelopes.Balance{"USD": big.NewRat(6709, 100)},
+								},
+								"restaurants": {
+									Balance: envelopes.Balance{"USD": big.NewRat(12933, 100)},
+								},
+							},
+						},
+						Accounts: envelopes.Accounts{
+							"checking": envelopes.Balance{"USD": big.NewRat(24153, 100)},
+						},
+					},
+				},
+				Expected: "0d186bf4bc88d299b483c3d3d8e2b0147529e50e",
+			},
 		}
 
 		for _, tc := range testCases {


### PR DESCRIPTION
Adds a field to the `envelopes.Transaction` type, and all included helpers, that helps indicate when a transaction exists to undo a former one.