### PR TITLE
Adding `persist.Merge` and supporting changes.

### DIFF
--- a/account.go
+++ b/account.go
@@ -84,3 +84,57 @@ func (accs Accounts) Balance() Balance {
 	}
 	return sum
 }
+
+// Add combines two lists of accounts. Taking the union of all distinct accounts, and where the same account appears in two places, it sums both balances.
+func (accs Accounts) Add(other Accounts) Accounts {
+	modifiedAccounts := make(Accounts, len(accs))
+
+	unseen := make(Accounts, len(other))
+	for otherName, otherBalance := range other {
+		unseen[otherName] = otherBalance
+	}
+
+	for currentName, currentBalance := range accs {
+		if otherBalance, ok := other[currentName]; ok {
+			delete(unseen, currentName)
+			if !currentBalance.Equal(otherBalance) {
+				modifiedAccounts[currentName] = currentBalance.Add(otherBalance)
+			}
+		} else {
+			modifiedAccounts[currentName] = currentBalance
+		}
+	}
+
+	for unseenName, unseenBalance := range unseen {
+		modifiedAccounts[unseenName] = unseenBalance
+	}
+
+	return modifiedAccounts
+}
+
+// Sub removes the amount from each `Balance` in other from the account it is invoked on.
+func (accs Accounts) Sub(other Accounts) Accounts {
+	modifiedAccounts := make(Accounts, len(accs))
+
+	unseen := make(Accounts, len(other))
+	for otherName, otherBalance := range other {
+		unseen[otherName] = otherBalance
+	}
+
+	for currentName, currentBalance := range accs {
+		if otherBalance, ok := other[currentName]; ok {
+			delete(unseen, currentName)
+			if !currentBalance.Equal(otherBalance) {
+				modifiedAccounts[currentName] = currentBalance.Sub(otherBalance)
+			}
+		} else {
+			modifiedAccounts[currentName] = currentBalance
+		}
+	}
+
+	for unseenName, unseenBalance := range unseen {
+		modifiedAccounts[unseenName] = unseenBalance.Negate()
+	}
+
+	return modifiedAccounts
+}

--- a/account.go
+++ b/account.go
@@ -138,3 +138,11 @@ func (accs Accounts) Sub(other Accounts) Accounts {
 
 	return modifiedAccounts
 }
+
+func (accs Accounts) DeepCopy() Accounts {
+	retval := make(Accounts, len(accs))
+	for k, v := range accs {
+		retval[k] = v.DeepCopy()
+	}
+	return retval
+}

--- a/balance.go
+++ b/balance.go
@@ -191,6 +191,16 @@ func (b Balance) Normalize(rates Exchange) (*big.Rat, error) {
 	return sum, nil
 }
 
+func (b Balance) DeepCopy() Balance {
+	retval := make(Balance, len(b))
+
+	for k, v := range b {
+		retval[k] = v
+	}
+
+	return retval
+}
+
 func (b Balance) String() string {
 	const defaultResult = "USD 0.00"
 	const precision = 3

--- a/budget.go
+++ b/budget.go
@@ -145,3 +145,89 @@ func (b Budget) ChildNames() (results []string) {
 	sort.Strings(results)
 	return
 }
+
+// Subtract removes the amount of each balance in `other` from the Budget this was invoked on.
+func (b *Budget) Subtract(other *Budget) *Budget {
+	// negate reverses the balances of all balances in a budget recursively.
+	var negate func(*Budget)
+	negate = func(subject *Budget) {
+		subject.Balance = subject.Balance.Negate()
+		for _, child := range subject.Children {
+			negate(child)
+		}
+	}
+
+	// helper subtracts the right child-budget from the left child-budget. Should be called on children with matching
+	// names
+	var helper func(*Budget, *Budget) *Budget
+	helper = func(left, right *Budget) *Budget {
+		modifiedChildren := make(map[string]*Budget)
+
+		// mark all of the children on the right, so we can decide if any got deleted after tallying all of the children
+		// on the left.
+		removedChildren := make(map[string]*Budget, len(right.Children))
+		for childName, child := range right.Children {
+			removedChildren[childName] = child
+		}
+
+		// enumerate through all of the left's children, to find any discrepancies.
+		for childName, leftChild := range left.Children {
+			if rightChild, ok := right.Children[childName]; ok {
+				// see if there are any differences between the children, only if there are should the modified child
+				// be added.
+				subtracted := helper(leftChild, rightChild)
+				if subtracted != nil {
+					modifiedChildren[childName] = subtracted
+				}
+
+				// regardless of whether or not there are differences, both budgets had this child.
+				delete(removedChildren, childName)
+			} else {
+				modifiedChildren[childName] = leftChild
+			}
+		}
+
+		// make a note of all of the children who were removed.
+		for childName, child := range removedChildren {
+			childClone := child.DeepCopy()
+			negate(&childClone)
+			modifiedChildren[childName] = &childClone
+		}
+
+		// finalize an object that represents the changes made, and send it up the stack.
+		var retval Budget
+
+		if len(modifiedChildren) > 0 {
+			retval.Children = modifiedChildren
+		}
+
+		if left.Balance.Equal(right.Balance) && retval.Children == nil {
+			return nil
+		}
+
+		retval.Balance = left.Balance.Sub(right.Balance)
+
+		return &retval
+	}
+
+	// If there are no budgets involved... do nothing and short-circuit.
+	if b == nil && other == nil {
+		return nil
+	}
+
+	// If this has a budget, but the other doesn't, just clone this budget. This budget has been added.
+	if other == nil {
+		cloned := b.DeepCopy()
+		return &cloned
+	}
+
+	// If this doesn't have a budget, but the other does, clone and negate that budget. That budget has been removed.
+	if b == nil {
+		cloned := other.DeepCopy()
+		negate(&cloned)
+		return &cloned
+	}
+
+	// Changes have been made to this budget. Call helper to get the differences figured out.
+	return helper(b, other)
+}

--- a/budget.go
+++ b/budget.go
@@ -44,13 +44,16 @@ type Budget struct {
 	Children map[string]*Budget
 }
 
-func (b Budget) deepCopy() Budget {
+// DeepCopy creates a new budget identical used to the one to invoke it, but
+// that is a totally separate instance. This allows you to edit the copied or
+// original without impacting the other.
+func (b Budget) DeepCopy() Budget {
 	var clone Budget
 	clone.Balance = b.Balance
 	clone.Children = make(map[string]*Budget, len(b.Children))
 
 	for childName, child := range b.Children {
-		clonedChild := child.deepCopy()
+		clonedChild := child.DeepCopy()
 		clone.Children[childName] = &clonedChild
 	}
 	return clone
@@ -120,7 +123,8 @@ func (b Budget) Equal(other Budget) bool {
 // RecursiveBalance finds the balance of a `Budget` and all of its children.
 //
 // See Also:
-// 	Budget.Balance
+//
+//	Budget.Balance
 func (b Budget) RecursiveBalance() (sum Balance) {
 	sum = b.Balance
 	for _, child := range b.Children {

--- a/persist/merge.go
+++ b/persist/merge.go
@@ -1,0 +1,57 @@
+package persist
+
+import (
+	"context"
+
+	"github.com/marstr/envelopes"
+)
+
+type Conflict struct {
+}
+
+func Merge(ctx context.Context, repo RepositoryReader, heads []RefSpec) (merged envelopes.State, conflicts []Conflict, err error) {
+	var headIDs []envelopes.ID
+	headIDs, err = ResolveMany(ctx, repo, heads)
+	if err != nil {
+		return
+	}
+
+	hydratedHeads := make([]envelopes.Transaction, len(headIDs))
+	for i, head := range headIDs {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+			return
+		default:
+			// Intentionally Left Blank
+		}
+
+		err = repo.LoadTransaction(ctx, head, &hydratedHeads[i])
+		if err != nil {
+			return
+		}
+	}
+
+	var ncaID envelopes.ID
+	ncaID, err = NearestCommonAncestorMany(ctx, repo, headIDs)
+	if err != nil {
+		return
+	}
+
+	var nca envelopes.Transaction
+	err = repo.LoadTransaction(ctx, ncaID, &nca)
+	if err != nil {
+		return
+	}
+
+	merged = nca.State.DeepCopy()
+
+	for i := range hydratedHeads {
+		delta := hydratedHeads[i].State.Subtract(*nca.State)
+		merged = envelopes.State(merged.Add(envelopes.State(delta)))
+	}
+
+	// TODO Walk all transactions from HEADs to nca and find Transactions with duplicate BankIDs, report those as conflicts in return value.
+
+	return
+}

--- a/persist/merge.go
+++ b/persist/merge.go
@@ -6,10 +6,7 @@ import (
 	"github.com/marstr/envelopes"
 )
 
-type Conflict struct {
-}
-
-func Merge(ctx context.Context, repo RepositoryReader, heads []RefSpec) (merged envelopes.State, conflicts []Conflict, err error) {
+func Merge(ctx context.Context, repo RepositoryReader, heads []RefSpec) (merged envelopes.State, err error) {
 	var headIDs []envelopes.ID
 	headIDs, err = ResolveMany(ctx, repo, heads)
 	if err != nil {
@@ -50,8 +47,6 @@ func Merge(ctx context.Context, repo RepositoryReader, heads []RefSpec) (merged 
 		delta := hydratedHeads[i].State.Subtract(*nca.State)
 		merged = envelopes.State(merged.Add(envelopes.State(delta)))
 	}
-
-	// TODO Walk all transactions from HEADs to nca and find Transactions with duplicate BankIDs, report those as conflicts in return value.
 
 	return
 }

--- a/persist/merge_test.go
+++ b/persist/merge_test.go
@@ -77,8 +77,7 @@ func TestMerge_Simple(t *testing.T) {
 	}
 
 	var got envelopes.State
-	var conflicts []persist.Conflict
-	got, conflicts, err = persist.Merge(ctx, repo, []persist.RefSpec{mainLine, feature})
+	got, err = persist.Merge(ctx, repo, []persist.RefSpec{mainLine, feature})
 	if err != nil {
 		fmt.Println("Failed: ", err)
 		return
@@ -91,10 +90,6 @@ func TestMerge_Simple(t *testing.T) {
 
 	if !got.Budget.Balance.Equal(expected) {
 		t.Errorf("incorrect budget balance\n\tgot:  %s\n\twant: %s", got, expected)
-	}
-
-	if len(conflicts) != 0 {
-		t.Errorf("unexpected conflicts: %v", len(conflicts))
 	}
 }
 
@@ -187,8 +182,7 @@ func TestMerge_Threeway(t *testing.T) {
 	}
 
 	var got envelopes.State
-	var conflicts []persist.Conflict
-	got, conflicts, err = persist.Merge(ctx, repo, []persist.RefSpec{mainLine, feature1, feature2})
+	got, err = persist.Merge(ctx, repo, []persist.RefSpec{mainLine, feature1, feature2})
 	if err != nil {
 		fmt.Println("Failed: ", err)
 		return
@@ -201,9 +195,5 @@ func TestMerge_Threeway(t *testing.T) {
 
 	if !got.Budget.Balance.Equal(expected) {
 		t.Errorf("incorrect budget balance\n\tgot:  %s\n\twant: %s", got, expected)
-	}
-
-	if len(conflicts) != 0 {
-		t.Errorf("unexpected conflicts: %v", len(conflicts))
 	}
 }

--- a/persist/merge_test.go
+++ b/persist/merge_test.go
@@ -1,0 +1,209 @@
+package persist_test
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/marstr/envelopes"
+	"github.com/marstr/envelopes/persist"
+)
+
+func TestMerge_Simple(t *testing.T) {
+	const mainLine = "main"
+	const feature = "alt"
+	ctx := context.Background()
+	var err error
+
+	repo := persist.NewMockRepository(2, 4)
+
+	initialBalances := envelopes.Transaction{
+		State: &envelopes.State{
+			Accounts: envelopes.Accounts{"checking": envelopes.Balance{"USD": big.NewRat(100, 1)}},
+			Budget:   &envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(100, 1)}},
+		},
+	}
+	err = repo.WriteTransaction(ctx, initialBalances)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	coffee := envelopes.Transaction{
+		Amount: envelopes.Balance{"USD": big.NewRat(3, 1)},
+		State: &envelopes.State{
+			Accounts: envelopes.Accounts{"checking": envelopes.Balance{"USD": big.NewRat(97, 1)}},
+			Budget:   &envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(97, 1)}},
+		},
+		Parents: []envelopes.ID{initialBalances.ID()},
+	}
+	err = repo.WriteTransaction(ctx, coffee)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	carwash := envelopes.Transaction{
+		Amount: envelopes.Balance{"USD": big.NewRat(15, 1)},
+		State: &envelopes.State{
+			Accounts: envelopes.Accounts{"checking": envelopes.Balance{"USD": big.NewRat(85, 1)}},
+			Budget:   &envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(85, 1)}},
+		},
+		Parents: []envelopes.ID{initialBalances.ID()},
+	}
+	err = repo.WriteTransaction(ctx, carwash)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = repo.WriteBranch(ctx, mainLine, coffee.ID())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = repo.WriteBranch(ctx, feature, carwash.ID())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = repo.SetCurrent(ctx, mainLine)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	var got envelopes.State
+	var conflicts []persist.Conflict
+	got, conflicts, err = persist.Merge(ctx, repo, []persist.RefSpec{mainLine, feature})
+	if err != nil {
+		fmt.Println("Failed: ", err)
+		return
+	}
+
+	expected := envelopes.Balance{"USD": big.NewRat(82, 1)}
+	if !got.Accounts["checking"].Equal(expected) {
+		t.Errorf("incorrect account balance\n\tgot:  %s\n\twant: %s", got, expected)
+	}
+
+	if !got.Budget.Balance.Equal(expected) {
+		t.Errorf("incorrect budget balance\n\tgot:  %s\n\twant: %s", got, expected)
+	}
+
+	if len(conflicts) != 0 {
+		t.Errorf("unexpected conflicts: %v", len(conflicts))
+	}
+}
+
+func TestMerge_Threeway(t *testing.T) {
+	const mainLine = "main"
+	const feature1 = "alt1"
+	const feature2 = "alt2"
+
+	ctx := context.Background()
+	var err error
+
+	repo := persist.NewMockRepository(3, 5)
+
+	initialBalances := envelopes.Transaction{
+		State: &envelopes.State{
+			Accounts: envelopes.Accounts{"checking": envelopes.Balance{"USD": big.NewRat(100, 1)}},
+			Budget:   &envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(100, 1)}},
+		},
+	}
+	err = repo.WriteTransaction(ctx, initialBalances)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	coffee := envelopes.Transaction{
+		Amount: envelopes.Balance{"USD": big.NewRat(3, 1)},
+		State: &envelopes.State{
+			Accounts: envelopes.Accounts{"checking": envelopes.Balance{"USD": big.NewRat(97, 1)}},
+			Budget:   &envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(97, 1)}},
+		},
+		Parents: []envelopes.ID{initialBalances.ID()},
+	}
+	err = repo.WriteTransaction(ctx, coffee)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	carwash := envelopes.Transaction{
+		Amount: envelopes.Balance{"USD": big.NewRat(15, 1)},
+		State: &envelopes.State{
+			Accounts: envelopes.Accounts{"checking": envelopes.Balance{"USD": big.NewRat(85, 1)}},
+			Budget:   &envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(85, 1)}},
+		},
+		Parents: []envelopes.ID{initialBalances.ID()},
+	}
+	err = repo.WriteTransaction(ctx, carwash)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	videogame := envelopes.Transaction{
+		Amount: envelopes.Balance{"USD": big.NewRat(60, 1)},
+		State: &envelopes.State{
+			Accounts: envelopes.Accounts{"checking": envelopes.Balance{"USD": big.NewRat(40, 1)}},
+			Budget:   &envelopes.Budget{Balance: envelopes.Balance{"USD": big.NewRat(40, 1)}},
+		},
+		Parents: []envelopes.ID{initialBalances.ID()},
+	}
+	err = repo.WriteTransaction(ctx, videogame)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = repo.WriteBranch(ctx, mainLine, coffee.ID())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = repo.WriteBranch(ctx, feature1, carwash.ID())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = repo.WriteBranch(ctx, feature2, videogame.ID())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = repo.SetCurrent(ctx, mainLine)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	var got envelopes.State
+	var conflicts []persist.Conflict
+	got, conflicts, err = persist.Merge(ctx, repo, []persist.RefSpec{mainLine, feature1, feature2})
+	if err != nil {
+		fmt.Println("Failed: ", err)
+		return
+	}
+
+	expected := envelopes.Balance{"USD": big.NewRat(22, 1)}
+	if !got.Accounts["checking"].Equal(expected) {
+		t.Errorf("incorrect account balance\n\tgot:  %s\n\twant: %s", got, expected)
+	}
+
+	if !got.Budget.Balance.Equal(expected) {
+		t.Errorf("incorrect budget balance\n\tgot:  %s\n\twant: %s", got, expected)
+	}
+
+	if len(conflicts) != 0 {
+		t.Errorf("unexpected conflicts: %v", len(conflicts))
+	}
+}

--- a/persist/repository.go
+++ b/persist/repository.go
@@ -120,7 +120,7 @@ func bareClone(ctx context.Context, src BareRepositoryReader, dest BareRepositor
 
 // Commit assigns the currently checked out commit as the parent of the provided transaction, writes that transaction,
 // then updates the reference to the currently checkout out branch as appropriate.
-func Commit(ctx context.Context, repo RepositoryReaderWriter, transaction envelopes.Transaction) error {
+func Commit(ctx context.Context, repo RepositoryReaderWriter, transaction envelopes.Transaction, additionalParents ...envelopes.ID) error {
 	head, err := repo.Current(ctx)
 	if err != nil {
 		return err
@@ -137,7 +137,10 @@ func Commit(ctx context.Context, repo RepositoryReaderWriter, transaction envelo
 	if parent.Equal(envelopes.ID{}) {
 		transaction.Parents = []envelopes.ID{}
 	} else {
-		transaction.Parents = []envelopes.ID{parent}
+		transaction.Parents = append([]envelopes.ID{parent}, additionalParents...)
+	}
+	if err != nil {
+		return err
 	}
 
 	err = repo.WriteTransaction(ctx, transaction)

--- a/state.go
+++ b/state.go
@@ -170,7 +170,7 @@ func (s State) subtractBudget(other State) *Budget {
 
 		// make a note of all of the children who were removed.
 		for childName, child := range removedChildren {
-			childClone := child.deepCopy()
+			childClone := child.DeepCopy()
 			negate(&childClone)
 			modifiedChildren[childName] = &childClone
 		}
@@ -198,13 +198,13 @@ func (s State) subtractBudget(other State) *Budget {
 
 	// If this has a budget, but the other doesn't, just clone this budget. This budget has been added.
 	if other.Budget == nil {
-		cloned := s.Budget.deepCopy()
+		cloned := s.Budget.DeepCopy()
 		return &cloned
 	}
 
 	// If this doesn't have a budget, but the other does, clone and negate that budget. That budget has been removed.
 	if s.Budget == nil {
-		cloned := other.Budget.deepCopy()
+		cloned := other.Budget.DeepCopy()
 		negate(&cloned)
 		return &cloned
 	}

--- a/state.go
+++ b/state.go
@@ -97,35 +97,17 @@ func (s State) String() string {
 // Subtract removes the balances of another State, and returns what changed between the two.
 func (s State) Subtract(other State) Impact {
 	return Impact{
-		Accounts: s.subtractAccounts(other),
+		Accounts: s.Accounts.Sub(other.Accounts),
 		Budget:   s.Budget.Subtract(other.Budget),
 	}
 }
 
-func (s State) subtractAccounts(other State) Accounts {
-	modifiedAccounts := make(Accounts, len(s.Accounts))
-
-	unseen := make(Accounts, len(other.Accounts))
-	for otherName, otherBalance := range other.Accounts {
-		unseen[otherName] = otherBalance
+// Add combines the baalances of another State and returns the total of both.
+func (s State) Add(other State) Impact {
+	return Impact{
+		Accounts: s.Accounts.Add(other.Accounts),
+		Budget:   s.Budget.Add(other.Budget),
 	}
-
-	for currentName, currentBalance := range s.Accounts {
-		if otherBalance, ok := other.Accounts[currentName]; ok {
-			delete(unseen, currentName)
-			if !currentBalance.Equal(otherBalance) {
-				modifiedAccounts[currentName] = currentBalance.Sub(otherBalance)
-			}
-		} else {
-			modifiedAccounts[currentName] = currentBalance
-		}
-	}
-
-	for unseenName, unseenBalance := range unseen {
-		modifiedAccounts[unseenName] = unseenBalance.Negate()
-	}
-
-	return modifiedAccounts
 }
 
 // CalculateAmount looks at the difference between two states, and boils down the changes

--- a/state.go
+++ b/state.go
@@ -110,6 +110,15 @@ func (s State) Add(other State) Impact {
 	}
 }
 
+// DeepCopy creates a duplicate state that can be modified without fear of modifying the original.
+func (s State) DeepCopy() State {
+	copiedBudget := s.Budget.DeepCopy()
+	return State{
+		Accounts: s.Accounts.DeepCopy(),
+		Budget:   &copiedBudget,
+	}
+}
+
 // CalculateAmount looks at the difference between two states, and boils down the changes
 // into a single number that captures the magnitude of the operation(s) that occured between
 // the two.

--- a/state.go
+++ b/state.go
@@ -98,7 +98,7 @@ func (s State) String() string {
 func (s State) Subtract(other State) Impact {
 	return Impact{
 		Accounts: s.subtractAccounts(other),
-		Budget:   s.subtractBudget(other),
+		Budget:   s.Budget.Subtract(other.Budget),
 	}
 }
 
@@ -126,91 +126,6 @@ func (s State) subtractAccounts(other State) Accounts {
 	}
 
 	return modifiedAccounts
-}
-
-func (s State) subtractBudget(other State) *Budget {
-	// negate reverses the balances of all balances in a budget recursively.
-	var negate func(*Budget)
-	negate = func(subject *Budget) {
-		subject.Balance = subject.Balance.Negate()
-		for _, child := range subject.Children {
-			negate(child)
-		}
-	}
-
-	// helper subtracts the right child-budget from the left child-budget. Should be called on children with matching
-	// names
-	var helper func(*Budget, *Budget) *Budget
-	helper = func(left, right *Budget) *Budget {
-		modifiedChildren := make(map[string]*Budget)
-
-		// mark all of the children on the right, so we can decide if any got deleted after tallying all of the children
-		// on the left.
-		removedChildren := make(map[string]*Budget, len(right.Children))
-		for childName, child := range right.Children {
-			removedChildren[childName] = child
-		}
-
-		// enumerate through all of the left's children, to find any discrepancies.
-		for childName, leftChild := range left.Children {
-			if rightChild, ok := right.Children[childName]; ok {
-				// see if there are any differences between the children, only if there are should the modified child
-				// be added.
-				subtracted := helper(leftChild, rightChild)
-				if subtracted != nil {
-					modifiedChildren[childName] = subtracted
-				}
-
-				// regardless of whether or not there are differences, both budgets had this child.
-				delete(removedChildren, childName)
-			} else {
-				modifiedChildren[childName] = leftChild
-			}
-		}
-
-		// make a note of all of the children who were removed.
-		for childName, child := range removedChildren {
-			childClone := child.DeepCopy()
-			negate(&childClone)
-			modifiedChildren[childName] = &childClone
-		}
-
-		// finalize an object that represents the changes made, and send it up the stack.
-		var retval Budget
-
-		if len(modifiedChildren) > 0 {
-			retval.Children = modifiedChildren
-		}
-
-		if left.Balance.Equal(right.Balance) && retval.Children == nil {
-			return nil
-		}
-
-		retval.Balance = left.Balance.Sub(right.Balance)
-
-		return &retval
-	}
-
-	// If there are no budgets involved... do nothing and short-circuit.
-	if s.Budget == nil && other.Budget == nil {
-		return nil
-	}
-
-	// If this has a budget, but the other doesn't, just clone this budget. This budget has been added.
-	if other.Budget == nil {
-		cloned := s.Budget.DeepCopy()
-		return &cloned
-	}
-
-	// If this doesn't have a budget, but the other does, clone and negate that budget. That budget has been removed.
-	if s.Budget == nil {
-		cloned := other.Budget.DeepCopy()
-		negate(&cloned)
-		return &cloned
-	}
-
-	// Changes have been made to this budget. Call helper to get the differences figured out.
-	return helper(s.Budget, other.Budget)
 }
 
 // CalculateAmount looks at the difference between two states, and boils down the changes


### PR DESCRIPTION
This functionality is added to support marstr/baronial#35. Doing it here ensures that all tools can easily use the same merging behavior.