### PR TITLE
Clear Reverts when Loading as applicable

### DIFF
--- a/persist/json/loader_v1.go
+++ b/persist/json/loader_v1.go
@@ -66,6 +66,7 @@ func (dl LoaderV1) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad 
 	toLoad.Committer.FullName = unmarshaled.Committer.FullName
 	toLoad.Committer.Email = unmarshaled.Committer.Email
 	toLoad.RecordID = envelopes.BankRecordID(unmarshaled.RecordId)
+	toLoad.Reverts = envelopes.ID{}
 
 	return nil
 }

--- a/persist/json/loader_v2.go
+++ b/persist/json/loader_v2.go
@@ -62,6 +62,7 @@ func (dl LoaderV2) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad 
 	toLoad.Committer.FullName = unmarshaled.Committer.FullName
 	toLoad.Committer.Email = unmarshaled.Committer.Email
 	toLoad.RecordID = envelopes.BankRecordID(unmarshaled.RecordId)
+	toLoad.Reverts = envelopes.ID{}
 
 	return nil
 }

--- a/persist/json/loader_v3.go
+++ b/persist/json/loader_v3.go
@@ -66,6 +66,8 @@ func (dl LoaderV3) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad 
 	toLoad.RecordID = envelopes.BankRecordID(unmarshaled.RecordId)
 	if unmarshaled.Reverts != nil {
 		toLoad.Reverts = *unmarshaled.Reverts
+	} else {
+		toLoad.Reverts = envelopes.ID{}
 	}
 
 	return nil

--- a/persist/json/loader_v3_test.go
+++ b/persist/json/loader_v3_test.go
@@ -1,0 +1,59 @@
+package json_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marstr/envelopes"
+	"github.com/marstr/envelopes/persist/json"
+)
+
+func TestLoaderV3_LoadTransaction_notNullingReverts(t *testing.T) {
+	ctx := context.Background()
+
+	var err error
+	mockFiles := NewMockFilesystem()
+	var writer *json.Writer
+
+	writer, err = json.NewWriterV3(mockFiles)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	desired := envelopes.Transaction{
+		Comment: "This transaction needs to not have the Reverts field",
+	}
+
+	err = writer.WriteTransaction(ctx, desired)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	bogus := envelopes.Transaction{
+		Comment: "Some nonsense",
+	}
+
+	var poisoned = envelopes.Transaction{
+		Reverts: bogus.ID(),
+		Comment: "This transaction needs to have the Reverts field, and it needs to be not set to the default ID",
+	}
+
+	var specimen *json.LoaderV3
+	specimen, err = json.NewLoaderV3(mockFiles)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = specimen.LoadTransaction(ctx, desired.ID(), &poisoned)
+	if err != nil {
+		t.Errorf("it should've been able to load this: %v", err)
+		return
+	}
+
+	if !poisoned.Reverts.Equal(envelopes.ID{}) {
+		t.Errorf("The poison value %q was discovered after a deemed successful load that should've cleared it.", poisoned.Reverts)
+	}
+}

--- a/persist/json/mock_filesystem_test.go
+++ b/persist/json/mock_filesystem_test.go
@@ -1,0 +1,36 @@
+package json_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/marstr/collection/v2"
+	"github.com/marstr/envelopes"
+)
+
+type MockFilesystem struct {
+	*collection.LRUCache[envelopes.ID, []byte]
+}
+
+func NewMockFilesystem() *MockFilesystem {
+	return NewMockFilesystemWithCapacity(10000) // Some arbitrary large number that feels like tests are unlikely to hit.
+}
+
+func NewMockFilesystemWithCapacity(cap uint) *MockFilesystem {
+	return &MockFilesystem{
+		LRUCache: collection.NewLRUCache[envelopes.ID, []byte](cap),
+	}
+}
+
+func (mf MockFilesystem) Stash(ctx context.Context, id envelopes.ID, payload []byte) error {
+	mf.Put(id, payload)
+	return nil
+}
+
+func (mf MockFilesystem) Fetch(ctx context.Context, id envelopes.ID) ([]byte, error) {
+	retval, ok := mf.Get(id)
+	if !ok {
+		return nil, fmt.Errorf("did not find a stashed objected with ID: %s", id)
+	}
+	return retval, nil
+}


### PR DESCRIPTION
Fixes #65

When you're loading an object you need to reassign every field, otherwise you'll inherit slop from the previous transaction you're overloading. This caused a sneaky bug for LoadAncestor, which reuses the same transaction while loading parents in a loop.