### PR TITLE
Update Transaction.Reverts to be an array of IDs instead of a single one.

### DIFF
--- a/persist/filesystem/filesystem_test.go
+++ b/persist/filesystem/filesystem_test.go
@@ -160,7 +160,7 @@ func TestFileSystem_TransactionRoundTrip(t *testing.T) {
 			},
 		},
 		{
-			Reverts: envelopes.Transaction{Comment: "Not very good"}.ID(),
+			Reverts: []envelopes.ID{envelopes.Transaction{Comment: "Not very good"}.ID()},
 			State: &envelopes.State{
 				Budget: &envelopes.Budget{
 					Balance: envelopes.Balance{"USD": big.NewRat(100, 1)},

--- a/persist/json/loader_v1.go
+++ b/persist/json/loader_v1.go
@@ -66,7 +66,7 @@ func (dl LoaderV1) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad 
 	toLoad.Committer.FullName = unmarshaled.Committer.FullName
 	toLoad.Committer.Email = unmarshaled.Committer.Email
 	toLoad.RecordID = envelopes.BankRecordID(unmarshaled.RecordId)
-	toLoad.Reverts = envelopes.ID{}
+	toLoad.Reverts = []envelopes.ID{}
 
 	return nil
 }

--- a/persist/json/loader_v2.go
+++ b/persist/json/loader_v2.go
@@ -62,7 +62,7 @@ func (dl LoaderV2) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad 
 	toLoad.Committer.FullName = unmarshaled.Committer.FullName
 	toLoad.Committer.Email = unmarshaled.Committer.Email
 	toLoad.RecordID = envelopes.BankRecordID(unmarshaled.RecordId)
-	toLoad.Reverts = envelopes.ID{}
+	toLoad.Reverts = []envelopes.ID{}
 
 	return nil
 }

--- a/persist/json/loader_v3.go
+++ b/persist/json/loader_v3.go
@@ -65,9 +65,9 @@ func (dl LoaderV3) LoadTransaction(ctx context.Context, id envelopes.ID, toLoad 
 	toLoad.Committer.Email = unmarshaled.Committer.Email
 	toLoad.RecordID = envelopes.BankRecordID(unmarshaled.RecordId)
 	if unmarshaled.Reverts != nil {
-		toLoad.Reverts = *unmarshaled.Reverts
+		toLoad.Reverts = unmarshaled.Reverts
 	} else {
-		toLoad.Reverts = envelopes.ID{}
+		toLoad.Reverts = []envelopes.ID{}
 	}
 
 	return nil

--- a/persist/json/loader_v3_test.go
+++ b/persist/json/loader_v3_test.go
@@ -36,7 +36,7 @@ func TestLoaderV3_LoadTransaction_notNullingReverts(t *testing.T) {
 	}
 
 	var poisoned = envelopes.Transaction{
-		Reverts: bogus.ID(),
+		Reverts: []envelopes.ID{bogus.ID()},
 		Comment: "This transaction needs to have the Reverts field, and it needs to be not set to the default ID",
 	}
 
@@ -53,7 +53,7 @@ func TestLoaderV3_LoadTransaction_notNullingReverts(t *testing.T) {
 		return
 	}
 
-	if !poisoned.Reverts.Equal(envelopes.ID{}) {
+	if len(poisoned.Reverts) != 0 {
 		t.Errorf("The poison value %q was discovered after a deemed successful load that should've cleared it.", poisoned.Reverts)
 	}
 }

--- a/persist/json/models_v3.go
+++ b/persist/json/models_v3.go
@@ -36,7 +36,7 @@ type (
 		Comment     string         `json:"comment"`
 		Committer   UserV3         `json:"committer,omitempty"`
 		RecordId    BankRecordIDV3 `json:"recordId,omitempty"`
-		Reverts     *envelopes.ID  `json:"reverts,omitempty"`
+		Reverts     []envelopes.ID `json:"reverts,omitempty"`
 		Parent      []envelopes.ID `json:"parent"`
 	}
 

--- a/persist/json/writer_v3.go
+++ b/persist/json/writer_v3.go
@@ -55,8 +55,8 @@ func (dw WriterV3) WriteTransaction(ctx context.Context, subject envelopes.Trans
 	toMarshal.Committer.FullName = subject.Committer.FullName
 	toMarshal.Committer.Email = subject.Committer.Email
 	toMarshal.RecordId = BankRecordIDV3(subject.RecordID)
-	if !subject.Reverts.Equal(envelopes.ID{}) {
-		toMarshal.Reverts = &subject.Reverts
+	if len(subject.Reverts) != 0 {
+		toMarshal.Reverts = subject.Reverts
 	}
 
 	err := dw.loopback.WriteState(ctx, *subject.State)

--- a/transaction.go
+++ b/transaction.go
@@ -34,7 +34,7 @@ type Transaction struct {
 	Comment     string
 	RecordID    BankRecordID
 	Parents     []ID
-	Reverts     ID
+	Reverts     []ID
 }
 
 // ID fetches a SHA1 hash of this object that will uniquely identify it.
@@ -97,8 +97,14 @@ func (t Transaction) Equal(other Transaction) bool {
 		return false
 	}
 
-	if !t.Reverts.Equal(other.Reverts) {
+	if len(t.Reverts) != len(other.Reverts) {
 		return false
+	}
+
+	for i := range t.Reverts {
+		if !t.Reverts[i].Equal(other.Reverts[i]) {
+			return false
+		}
 	}
 
 	if len(t.Parents) != len(other.Parents) {
@@ -177,8 +183,12 @@ func (t Transaction) MarshalText() ([]byte, error) {
 			return nil, err
 		}
 	}
-	if !t.Reverts.Equal(ID{}) {
-		_, err = fmt.Fprintf(identityBuilder, "reverts %s\n", t.Reverts.String())
+	if len(t.Reverts) > 0 {
+		strRevs := make([]string, len(t.Reverts))
+		for i := range t.Reverts {
+			strRevs[i] = t.Reverts[i].String()
+		}
+		_, err = fmt.Fprintf(identityBuilder, "reverts %s\n", strings.Join(strRevs, ","))
 		if err != nil {
 			return nil, err
 		}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -125,7 +125,9 @@ func getTestTransactionIDLock(ctx context.Context) func(*testing.T) {
 						envelopes.Transaction{}.ID(),
 					},
 					RecordID: "20201212 575073 2,000 202,012,128,756",
-					Reverts:  envelopes.Transaction{Comment: "Clearly erroneous"}.ID(),
+					Reverts: []envelopes.ID{
+						envelopes.Transaction{Comment: "Clearly erroneous"}.ID(),
+					},
 					State: &envelopes.State{
 						Budget: &envelopes.Budget{
 							Balance: envelopes.Balance{"USD": big.NewRat(4511, 100)},


### PR DESCRIPTION
Fixes #81 