### PR TITLE
Go back to having branches readable

### DIFF
--- a/persist/filesystem/filesystem.go
+++ b/persist/filesystem/filesystem.go
@@ -173,7 +173,7 @@ func (fs FileSystem) WriteBranch(_ context.Context, name string, id envelopes.ID
 		return err
 	}
 
-	return os.WriteFile(branchLoc, id[:], fs.getCreatePermissions())
+	return os.WriteFile(branchLoc, []byte(id.String()), fs.getCreatePermissions())
 }
 
 // ListBranches fetches the distinct names of the branches that exist in a repository.

--- a/persist/filesystem/filesystem_test.go
+++ b/persist/filesystem/filesystem_test.go
@@ -137,10 +137,58 @@ func TestFileSystem_RoundTrip_Current(t *testing.T) {
 	}
 }
 
+func TestFileSystem_WriteBranch(t *testing.T) {
+	var ctx context.Context
+	deadline, ok := t.Deadline()
+	if ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
+
+	testLoc, err := os.MkdirTemp("", "envelopes")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	subject := filesystem.FileSystem{
+		Root: testLoc,
+	}
+
+	expected := envelopes.Transaction{
+		Comment: "Freedom is secured not by the fulfilling of one's desires, but by the removal of desire... No man is free who is not master of himself.",
+	}.ID()
+
+	err = subject.WriteBranch(ctx, persist.DefaultBranch, expected)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	got, err := subject.ReadBranch(ctx, persist.DefaultBranch)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if !got.Equal(expected) {
+		t.Errorf("round trip failed.\n\tgot:  %s\n\twant: %s", got, expected)
+	}
+}
+
 func TestFileSystem_TransactionRoundTrip(t *testing.T) {
-	// ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	// defer cancel()
-	ctx := context.Background()
+	var ctx context.Context
+	deadline, ok := t.Deadline()
+	if ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
 
 	testCases := []envelopes.Transaction{
 		{},


### PR DESCRIPTION
In a previous commit, I accidentally wrote branches as binary instead of as a readable encoding like utf-8.